### PR TITLE
feat(Overrides): Move overrides from application environment to the `sign_in_route` macro.

### DIFF
--- a/dev/dev_web/auth_overrides.ex
+++ b/dev/dev_web/auth_overrides.ex
@@ -1,0 +1,9 @@
+defmodule DevWeb.AuthOverrides do
+  @moduledoc false
+  use AshAuthentication.Phoenix.Overrides
+  alias AshAuthentication.Phoenix.Components
+
+  override Components.Banner do
+    set :image_url, "https://media.giphy.com/media/g7GKcSzwQfugw/giphy.gif"
+  end
+end

--- a/dev/dev_web/router.ex
+++ b/dev/dev_web/router.ex
@@ -32,7 +32,7 @@ defmodule DevWeb.Router do
   scope "/", DevWeb do
     pipe_through :browser
     auth_routes_for(Example.Accounts.User, to: AuthController, path: "/auth")
-    sign_in_route("/sign-in")
+    sign_in_route(overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default])
     sign_out_route(AuthController, "/sign-out")
   end
 end

--- a/lib/ash_authentication_phoenix/components/banner.ex
+++ b/lib/ash_authentication_phoenix/components/banner.ex
@@ -14,35 +14,47 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
   Can show either an image or some text, depending on the provided overrides.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
+
+   ## Props
+
+      * `overrides` - A list of override modules.
   """
 
   use Phoenix.LiveComponent
-  alias Phoenix.LiveView.{Rendered, Socket}
+  alias Phoenix.LiveView.Rendered
+
+  @type props :: %{
+          optional(:overrides) => [module]
+        }
 
   @doc false
   @impl true
-  @spec render(Socket.assigns()) :: Rendered.t() | no_return
+  @spec render(props) :: Rendered.t() | no_return
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
-      <%= case {override_for(@socket, :href_url), override_for(@socket, :image_url)} do %>
+    <div class={override_for(@overrides, :root_class)}>
+      <%= case {override_for(@overrides, :href_url), override_for(@overrides, :image_url)} do %>
         <% {nil, nil} -> %>
         <% {nil, img} -> %>
-          <img class={override_for(@socket, :image_class)} src={img} />
+          <img class={override_for(@overrides, :image_class)} src={img} />
         <% {hrf, img} -> %>
-          <a class={override_for(@socket, :href_class)} href={hrf}>
-            <img class={override_for(@socket, :image_class)} src={img} />
+          <a class={override_for(@overrides, :href_class)} href={hrf}>
+            <img class={override_for(@overrides, :image_class)} src={img} />
           </a>
       <% end %>
-      <%= case  {override_for(@socket, :href_url), override_for(@socket, :text)} do %>
+      <%= case  {override_for(@overrides, :href_url), override_for(@overrides, :text)} do %>
         <% {nil, nil} -> %>
         <% {nil, txt} -> %>
-          <div class={override_for(@socket, :text_class)}>
+          <div class={override_for(@overrides, :text_class)}>
             <%= txt %>
           </div>
         <% {hrf, txt} -> %>
-          <div class={override_for(@socket, :text_class)}>
-            <a class={override_for(@socket, :href_class)} href={hrf}>
+          <div class={override_for(@overrides, :text_class)}>
+            <a class={override_for(@overrides, :href_class)} href={hrf}>
               <%= txt %>
             </a>
           </div>

--- a/lib/ash_authentication_phoenix/components/horizontal_rule.ex
+++ b/lib/ash_authentication_phoenix/components/horizontal_rule.ex
@@ -14,23 +14,35 @@ defmodule AshAuthentication.Phoenix.Components.HorizontalRule do
   certain look.  If you think I'm wrong then please let me know.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
+
+  ## Props
+
+      * `overrides` - A list of override modules.
   """
 
   use Phoenix.LiveComponent
-  alias Phoenix.LiveView.{Rendered, Socket}
+  alias Phoenix.LiveView.Rendered
+
+  @type props :: %{
+          optional(:overrides) => [module]
+        }
 
   @doc false
   @impl true
-  @spec render(Socket.assigns()) :: Rendered.t() | no_return
+  @spec render(props) :: Rendered.t() | no_return
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
-      <div class={override_for(@socket, :hr_outer_class)} aria-hidden="true">
-        <div class={override_for(@socket, :hr_inner_class)}></div>
+    <div class={override_for(@overrides, :root_class)}>
+      <div class={override_for(@overrides, :hr_outer_class)} aria-hidden="true">
+        <div class={override_for(@overrides, :hr_inner_class)}></div>
       </div>
-      <div class={override_for(@socket, :text_outer_class)}>
-        <span class={override_for(@socket, :text_inner_class)}>
-          <%= override_for(@socket, :text) %>
+      <div class={override_for(@overrides, :text_outer_class)}>
+        <span class={override_for(@overrides, :text_inner_class)}>
+          <%= override_for(@overrides, :text) %>
         </span>
       </div>
     </div>

--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -15,26 +15,32 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
 
     * `strategy` - The strategy configuration as per
       `AshAuthentication.Info.strategy/2`.  Required.
-    * `socket` - Needed to infer the otp-app from the Phoenix endpoint.
+    * `overrides` - A list of override modules.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
   use Phoenix.LiveComponent
   alias AshAuthentication.Info
-  alias Phoenix.LiveView.{Rendered, Socket}
+  alias Phoenix.LiveView.Rendered
   import AshAuthentication.Phoenix.Components.Helpers, only: [route_helpers: 1]
   import Phoenix.HTML.Form
 
+  @type props :: %{
+          required(:strategy) => AshAuthentication.Strategy.t(),
+          optional(:overrides) => [module]
+        }
+
   @doc false
-  @spec render(Socket.assigns()) :: Rendered.t() | no_return
+  @spec render(props) :: Rendered.t() | no_return
   def render(assigns) do
     assigns =
       assigns
       |> assign(:subject_name, Info.authentication_subject_name!(assigns.strategy.resource))
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
+    <div class={override_for(@overrides, :root_class)}>
       <a
         href={
           route_helpers(@socket).auth_path(
@@ -42,7 +48,7 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
             {@subject_name, @strategy.name, :request}
           )
         }
-        class={override_for(@socket, :link_class)}
+        class={override_for(@overrides, :link_class)}
       >
         Sign in with <%= strategy_name(@strategy) %>
       </a>

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -27,7 +27,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
 
     * `strategy` - The strategy configuration as per
       `AshAuthentication.Info.strategy/2`.  Required.
-    * `socket` - Needed to infer the otp-app from the Phoenix endpoint.
+    * `overrides` - A list of override modules.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
@@ -37,8 +37,13 @@ defmodule AshAuthentication.Phoenix.Components.Password do
   alias Phoenix.LiveView.{JS, Rendered, Socket}
   import Slug
 
+  @type props :: %{
+          required(:strategy) => AshAuthentication.Strategy.t(),
+          optional(:overrides) => [module]
+        }
+
   @doc false
-  @spec render(Socket.assigns()) :: Rendered.t() | no_return
+  @spec render(props) :: Rendered.t() | no_return
   def render(assigns) do
     strategy = assigns.strategy
 
@@ -72,27 +77,30 @@ defmodule AshAuthentication.Phoenix.Components.Password do
         :register_id,
         generate_id(subject_name, strategy_name, strategy.register_action_name)
       )
-      |> assign(:show_first, override_for(assigns.socket, :show_first, :sign_in))
-      |> assign(:hide_class, override_for(assigns.socket, :hide_class))
+      |> assign(:show_first, override_for(assigns.overrides, :show_first, :sign_in))
+      |> assign(:hide_class, override_for(assigns.overrides, :hide_class))
       |> assign(:reset_enabled?, reset_enabled?)
       |> assign(:reset_id, reset_id)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
+    <div class={override_for(@overrides, :root_class)}>
       <div id={"#{@sign_in_id}-wrapper"} class={unless @show_first == :sign_in, do: @hide_class}>
         <.live_component
           module={Password.SignInForm}
           id={@sign_in_id}
           strategy={@strategy}
           label={false}
+          overrides={@overrides}
         >
-          <div class={override_for(@socket, :interstitial_class)}>
+          <div class={override_for(@overrides, :interstitial_class)}>
             <%= if @reset_enabled? do %>
               <.toggler
                 socket={@socket}
                 show={@reset_id}
                 hide={[@sign_in_id, @register_id]}
-                message={override_for(@socket, :reset_toggle_text)}
+                message={override_for(@overrides, :reset_toggle_text)}
+                overrides={@overrides}
               />
             <% end %>
 
@@ -100,7 +108,8 @@ defmodule AshAuthentication.Phoenix.Components.Password do
               socket={@socket}
               show={@register_id}
               hide={[@sign_in_id, @reset_id]}
-              message={override_for(@socket, :register_toggle_text)}
+              message={override_for(@overrides, :register_toggle_text)}
+              overrides={@overrides}
             />
           </div>
         </.live_component>
@@ -112,21 +121,24 @@ defmodule AshAuthentication.Phoenix.Components.Password do
           id={@register_id}
           strategy={@strategy}
           label={false}
+          overrides={@overrides}
         >
-          <div class={override_for(@socket, :interstitial_class)}>
+          <div class={override_for(@overrides, :interstitial_class)}>
             <%= if @reset_enabled? do %>
               <.toggler
                 socket={@socket}
                 show={@reset_id}
                 hide={[@sign_in_id, @register_id]}
-                message={override_for(@socket, :reset_toggle_text)}
+                message={override_for(@overrides, :reset_toggle_text)}
+                overrides={@overrides}
               />
             <% end %>
             <.toggler
               socket={@socket}
               show={@sign_in_id}
               hide={[@register_id, @reset_id]}
-              message={override_for(@socket, :sign_in_toggle_text)}
+              message={override_for(@overrides, :sign_in_toggle_text)}
+              overrides={@overrides}
             />
           </div>
         </.live_component>
@@ -139,19 +151,22 @@ defmodule AshAuthentication.Phoenix.Components.Password do
             id={@reset_id}
             strategy={@strategy}
             label={false}
+            overrides={@overrides}
           >
-            <div class={override_for(@socket, :interstitial_class)}>
+            <div class={override_for(@overrides, :interstitial_class)}>
               <.toggler
                 socket={@socket}
                 show={@register_id}
                 hide={[@sign_in_id, @reset_id]}
-                message={override_for(@socket, :register_toggle_text)}
+                message={override_for(@overrides, :register_toggle_text)}
+                overrides={@overrides}
               />
               <.toggler
                 socket={@socket}
                 show={@sign_in_id}
                 hide={[@register_id, @reset_id]}
-                message={override_for(@socket, :sign_in_toggle_text)}
+                message={override_for(@overrides, :sign_in_toggle_text)}
+                overrides={@overrides}
               />
             </div>
           </.live_component>
@@ -174,7 +189,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
   @spec toggler(Socket.assigns()) :: Rendered.t() | no_return
   def toggler(assigns) do
     ~H"""
-    <a href="#" phx-click={toggle_js(@show, @hide)} class={override_for(@socket, :toggler_class)}>
+    <a href="#" phx-click={toggle_js(@show, @hide)} class={override_for(@overrides, :toggler_class)}>
       <%= @message %>
     </a>
     """

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -45,15 +45,21 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       Required.
     * `input_type` - Either `:text` or `:email`.
       If not set it will try and guess based on the name of the identity field.
+    * `overrides` - A list of override modules.
   """
   @spec identity_field(%{
           required(:socket) => Socket.t(),
           required(:strategy) => Strategy.t(),
           required(:form) => Form.t(),
-          optional(:input_type) => :text | :email
+          optional(:input_type) => :text | :email,
+          optional(:overrides) => [module]
         }) :: Rendered.t() | no_return
   def identity_field(assigns) do
     identity_field = assigns.strategy.identity_field
+
+    assigns =
+      assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     assigns =
       assigns
@@ -69,21 +75,21 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       end)
       |> assign_new(:input_class, fn ->
         if has_error?(assigns.form, identity_field) do
-          override_for(assigns.socket, :input_class_with_error)
+          override_for(assigns.overrides, :input_class_with_error)
         else
-          override_for(assigns.socket, :input_class)
+          override_for(assigns.overrides, :input_class)
         end
       end)
 
     ~H"""
-    <div class={override_for(@socket, :field_class)}>
-      <%= label(@form, @identity_field, class: override_for(@socket, :label_class)) %>
+    <div class={override_for(@overrides, :field_class)}>
+      <%= label(@form, @identity_field, class: override_for(@overrides, :label_class)) %>
       <%= text_input(@form, @identity_field,
         type: to_string(@input_type),
         class: @input_class,
-        phx_debounce: override_for(@socket, :input_debounce)
+        phx_debounce: override_for(@overrides, :input_debounce)
       ) %>
-      <.error socket={@socket} form={@form} field={@identity_field} />
+      <.error socket={@socket} form={@form} field={@identity_field} overrides={@overrides} />
     </div>
     """
   end
@@ -93,43 +99,46 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
   ## Props
 
-    * `socket` - Phoenix LiveView socket.
-      This is needed to be able to retrieve the correct CSS configuration.
-      Required.
+    * `socket` - Phoenix LiveView socket.  This is needed to be able to retrieve
+      the correct CSS configuration.  Required.
     * `strategy` - The configuration map as per
-      `AshAuthentication.authenticated_resources/1`.
-      Required.
-    * `form` - An `AshPhoenix.Form`.
-      Required.
+      `AshAuthentication.authenticated_resources/1`.  Required.
+    * `form` - An `AshPhoenix.Form`.  Required.
+    * `overrides` - A list of override modules.
   """
   @spec password_field(%{
           required(:socket) => Socket.t(),
           required(:strategy) => Strategy.t(),
-          required(:form) => Form.t()
+          required(:form) => Form.t(),
+          optional(:overrides) => [module]
         }) :: Rendered.t() | no_return
   def password_field(assigns) do
     password_field = assigns.strategy.password_field
 
     assigns =
       assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+
+    assigns =
+      assigns
       |> assign(:password_field, password_field)
       |> assign_new(:input_class, fn ->
         if has_error?(assigns.form, password_field) do
-          override_for(assigns.socket, :input_class_with_error)
+          override_for(assigns.overrides, :input_class_with_error)
         else
-          override_for(assigns.socket, :input_class)
+          override_for(assigns.overrides, :input_class)
         end
       end)
 
     ~H"""
-    <div class={override_for(@socket, :field_class)}>
-      <%= label(@form, @password_field, class: override_for(@socket, :label_class)) %>
+    <div class={override_for(@overrides, :field_class)}>
+      <%= label(@form, @password_field, class: override_for(@overrides, :label_class)) %>
       <%= password_input(@form, @password_field,
         class: @input_class,
         value: input_value(@form, @password_field),
-        phx_debounce: override_for(@socket, :input_debounce)
+        phx_debounce: override_for(@overrides, :input_debounce)
       ) %>
-      <.error socket={@socket} form={@form} field={@password_field} />
+      <.error socket={@socket} form={@form} field={@password_field} overrides={@overrides} />
     </div>
     """
   end
@@ -139,43 +148,51 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
   ## Props
 
-    * `socket` - Phoenix LiveView socket.
-      This is needed to be able to retrieve the correct CSS configuration.
-      Required.
+    * `socket` - Phoenix LiveView socket.  This is needed to be able to retrieve
+      the correct CSS configuration.  Required.
     * `strategy` - The configuration map as per
-      `AshAuthentication.authenticated_resources/1`.
-      Required.
-    * `form` - An `AshPhoenix.Form`.
-      Required.
+      `AshAuthentication.authenticated_resources/1`.  Required.
+    * `form` - An `AshPhoenix.Form`.  Required.
+    * `overrides` - A list of override modules.
   """
   @spec password_confirmation_field(%{
           required(:socket) => Socket.t(),
           required(:strategy) => Strategy.t(),
-          required(:form) => Form.t()
+          required(:form) => Form.t(),
+          optional(:overrides) => [module]
         }) :: Rendered.t() | no_return
   def password_confirmation_field(assigns) do
     password_confirmation_field = assigns.strategy.password_confirmation_field
 
     assigns =
       assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+
+    assigns =
+      assigns
       |> assign(:password_confirmation_field, password_confirmation_field)
       |> assign_new(:input_class, fn ->
         if has_error?(assigns.form, password_confirmation_field) do
-          override_for(assigns.socket, :input_class_with_error)
+          override_for(assigns.overrides, :input_class_with_error)
         else
-          override_for(assigns.socket, :input_class)
+          override_for(assigns.overrides, :input_class)
         end
       end)
 
     ~H"""
-    <div class={override_for(@socket, :field_class)}>
-      <%= label(@form, @password_confirmation_field, class: override_for(@socket, :label_class)) %>
+    <div class={override_for(@overrides, :field_class)}>
+      <%= label(@form, @password_confirmation_field, class: override_for(@overrides, :label_class)) %>
       <%= password_input(@form, @password_confirmation_field,
         class: @input_class,
         value: input_value(@form, @password_confirmation_field),
-        phx_debounce: override_for(@socket, :input_debounce)
+        phx_debounce: override_for(@overrides, :input_debounce)
       ) %>
-      <.error socket={@socket} form={@form} field={@password_confirmation_field} />
+      <.error
+        socket={@socket}
+        form={@form}
+        field={@password_confirmation_field}
+        overrides={@overrides}
+      />
     </div>
     """
   end
@@ -185,30 +202,29 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
   ## Props
 
-    * `socket` - Phoenix LiveView socket.
-      This is needed to be able to retrieve the correct CSS configuration.
-      Required.
+    * `socket` - Phoenix LiveView socket.  This is needed to be able to retrieve
+      the correct CSS configuration.  Required.
     * `strategy` - The configuration map as per
-      `AshAuthentication.authenticated_resources/1`.
-      Required.
-    * `form` - An `AshPhoenix.Form`.
-      Required.
-    * `action` - Either `:sign_in` or `:register`.
-      Required.
-    * `label` - The text to show in the submit label.
-      Generated from the configured action name (via
-      `Phoenix.HTML.Form.humanize/1`) if not supplied.
+      `AshAuthentication.authenticated_resources/1`.  Required.
+    * `form` - An `AshPhoenix.Form`.  Required.
+    * `action` - Either `:sign_in` or `:register`.  Required.
+    * `label` - The text to show in the submit label.  Generated from the
+      configured action name (via `Phoenix.HTML.Form.humanize/1`) if not
+      supplied.
+    * `overrides` - A list of override modules.
   """
   @spec submit(%{
           required(:socket) => Socket.t(),
           required(:strategy) => Strategy.t(),
           required(:form) => Form.t(),
           required(:action) => :sign_in | :register,
-          optional(:label) => String.t()
+          optional(:label) => String.t(),
+          optional(:overrides) => [module]
         }) :: Rendered.t() | no_return
   def submit(assigns) do
     assigns =
       assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:label, fn ->
         case assigns.action do
           :request_reset ->
@@ -227,7 +243,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       |> assign_new(:disable_text, fn -> nil end)
 
     ~H"""
-    <%= submit(@label, class: override_for(@socket, :submit_class), phx_disable_with: @disable_text) %>
+    <%= submit(@label, class: override_for(@overrides, :submit_class), phx_disable_with: @disable_text) %>
     """
   end
 
@@ -236,13 +252,11 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
   ## Props
 
-    * `socket` - Phoenix LiveView socket.
-      This is needed to be able to retrieve the correct CSS configuration.
-      Required.
-    * `form` - An `AshPhoenix.Form`.
-      Required.
-    * `field` - The field for which to retrieve the errors.
-      Required.
+    * `socket` - Phoenix LiveView socket.  This is needed to be able to retrieve
+      the correct CSS configuration.  Required.
+    * `form` - An `AshPhoenix.Form`.  Required.
+    * `field` - The field for which to retrieve the errors.  Required.
+    * `overrides` - A list of override modules.
   """
   @spec error(%{
           required(:socket) => Socket.t(),
@@ -254,6 +268,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
   def error(assigns) do
     assigns =
       assigns
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:errors, fn ->
         assigns.form
         |> Form.errors()
@@ -263,9 +278,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     ~H"""
     <%= if Enum.any?(@errors) do %>
-      <ul class={override_for(@socket, :error_ul)}>
+      <ul class={override_for(@overrides, :error_ul)}>
         <%= for error <- @errors do %>
-          <li class={override_for(@socket, :error_li)} phx-feedback-for={input_name(@form, @field)}>
+          <li class={override_for(@overrides, :error_li)} phx-feedback-for={input_name(@form, @field)}>
             <%= @field_label %> <%= error %>
           </li>
         <% end %>

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -25,6 +25,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
     * `strategy` - The strategy configuration as per
       `AshAuthentication.Info.strategy/2`.  Required.
     * `socket` - Needed to infer the otp-app from the Phoenix endpoint.
+    * `overrides` - A list of override modules.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
@@ -39,9 +40,14 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
   import AshAuthentication.Phoenix.Components.Helpers
   import Slug
 
+  @type props :: %{
+          required(:strategy) => AshAuthentication.Strategy.t(),
+          optional(:overrides) => [module]
+        }
+
   @doc false
   @impl true
-  @spec update(Socket.assigns(), Socket.t()) :: {:ok, Socket.t()}
+  @spec update(props, Socket.t()) :: {:ok, Socket.t()}
   def update(assigns, socket) do
     strategy = assigns.strategy
 
@@ -67,6 +73,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
       )
       |> assign_new(:label, fn -> humanize(strategy.register_action_name) end)
       |> assign_new(:inner_block, fn -> nil end)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     {:ok, socket}
   end
@@ -76,9 +83,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
   @spec render(Socket.assigns()) :: Rendered.t() | no_return
   def render(assigns) do
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
+    <div class={override_for(@overrides, :root_class)}>
       <%= if @label do %>
-        <h2 class={override_for(@socket, :label_class)}>
+        <h2 class={override_for(@overrides, :label_class)}>
           <%= @label %>
         </h2>
       <% end %>
@@ -97,17 +104,32 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
           )
         }
         method="POST"
-        class={override_for(@socket, :form_class)}
+        class={override_for(@overrides, :form_class)}
       >
-        <Input.identity_field socket={@socket} strategy={@strategy} form={form} />
-        <Input.password_field socket={@socket} strategy={@strategy} form={form} />
+        <Input.identity_field
+          socket={@socket}
+          strategy={@strategy}
+          form={form}
+          overrides={@overrides}
+        />
+        <Input.password_field
+          socket={@socket}
+          strategy={@strategy}
+          form={form}
+          overrides={@overrides}
+        />
 
         <%= if @strategy.confirmation_required? do %>
-          <Input.password_confirmation_field socket={@socket} strategy={@strategy} form={form} />
+          <Input.password_confirmation_field
+            socket={@socket}
+            strategy={@strategy}
+            form={form}
+            overrides={@overrides}
+          />
         <% end %>
 
         <%= if @inner_block do %>
-          <div class={override_for(@socket, :slot_class)}>
+          <div class={override_for(@overrides, :slot_class)}>
             <%= render_slot(@inner_block) %>
           </div>
         <% end %>
@@ -117,7 +139,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
           strategy={@strategy}
           form={form}
           action={:register}
-          disable_text={override_for(@socket, :disable_button_text)}
+          disable_text={override_for(@overrides, :disable_button_text)}
+          overrides={@overrides}
         />
       </.form>
     </div>

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -27,6 +27,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
     * `label` - The text to show in the submit label.  Generated from the
       configured action name (via `Phoenix.HTML.Form.humanize/1`) if not
       supplied.  Set to `false` to disable.
+    * `overrides` - A list of override modules.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
@@ -40,9 +41,15 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
   import AshAuthentication.Phoenix.Components.Helpers
   import Slug
 
+  @type props :: %{
+          required(:strategy) => AshAuthentication.Strategy.t(),
+          optional(:label) => String.t() | false,
+          optional(:overrides) => [module]
+        }
+
   @doc false
   @impl true
-  @spec update(Socket.assigns(), Socket.t()) :: {:ok, Socket.t()}
+  @spec update(props, Socket.t()) :: {:ok, Socket.t()}
   def update(assigns, socket) do
     strategy = assigns.strategy
     form = blank_form(strategy)
@@ -53,6 +60,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
       |> assign(form: form, subject_name: Info.authentication_subject_name!(strategy.resource))
       |> assign_new(:label, fn -> strategy.request_password_reset_action_name end)
       |> assign_new(:inner_block, fn -> nil end)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     {:ok, socket}
   end
@@ -62,9 +70,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
   @spec render(Socket.assigns()) :: Rendered.t() | no_return
   def render(assigns) do
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
+    <div class={override_for(@overrides, :root_class)}>
       <%= if @label do %>
-        <h2 class={override_for(@socket, :label_class)}>
+        <h2 class={override_for(@overrides, :label_class)}>
           <%= @label %>
         </h2>
       <% end %>
@@ -82,12 +90,17 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
           )
         }
         method="POST"
-        class={override_for(@socket, :form_class)}
+        class={override_for(@overrides, :form_class)}
       >
-        <Input.identity_field socket={@socket} strategy={@strategy} form={form} />
+        <Input.identity_field
+          socket={@socket}
+          strategy={@strategy}
+          form={form}
+          overrides={@overrides}
+        />
 
         <%= if @inner_block do %>
-          <div class={override_for(@socket, :slot_class)}>
+          <div class={override_for(@overrides, :slot_class)}>
             <%= render_slot(@inner_block) %>
           </div>
         <% end %>
@@ -97,7 +110,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
           strategy={@strategy}
           form={form}
           action={:request_reset}
-          disable_text={override_for(@socket, :disable_button_text)}
+          disable_text={override_for(@overrides, :disable_button_text)}
+          overrides={@overrides}
         />
       </.form>
     </div>

--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -21,13 +21,12 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
 
   ## Props
 
-    * `socket` - Phoenix LiveView socket.  This is needed to be able to retrieve
-      the correct CSS configuration. Required.
     * `strategy` - The configuration map as per
       `AshAuthentication.Info.strategy/2`. Required.
     * `label` - The text to show in the submit label. Generated from the
       configured action name (via `Phoenix.HTML.Form.humanize/1`) if not
       supplied. Set to `false` to disable.
+    * `overrides` - A list of override modules.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
@@ -42,9 +41,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
   import Slug
 
   @type props :: %{
-          required(:socket) => Socket.t(),
           required(:strategy) => AshAuthentication.Strategy.t(),
-          optional(:label) => String.t() | false
+          optional(:label) => String.t() | false,
+          optional(:overrides) => [module]
         }
 
   @doc false
@@ -70,6 +69,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
       |> assign(form: form, trigger_action: false, subject_name: subject_name)
       |> assign_new(:label, fn -> humanize(strategy.sign_in_action_name) end)
       |> assign_new(:inner_block, fn -> nil end)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     {:ok, socket}
   end
@@ -79,9 +79,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
   @spec render(Socket.assigns()) :: Rendered.t() | no_return
   def render(assigns) do
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
+    <div class={override_for(@overrides, :root_class)}>
       <%= if @label do %>
-        <h2 class={override_for(@socket, :label_class)}><%= @label %></h2>
+        <h2 class={override_for(@overrides, :label_class)}><%= @label %></h2>
       <% end %>
 
       <.form
@@ -98,13 +98,23 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
           )
         }
         method="POST"
-        class={override_for(@socket, :form_class)}
+        class={override_for(@overrides, :form_class)}
       >
-        <Password.Input.identity_field socket={@socket} strategy={@strategy} form={form} />
-        <Password.Input.password_field socket={@socket} strategy={@strategy} form={form} />
+        <Password.Input.identity_field
+          socket={@socket}
+          strategy={@strategy}
+          form={form}
+          overrides={@overrides}
+        />
+        <Password.Input.password_field
+          socket={@socket}
+          strategy={@strategy}
+          form={form}
+          overrides={@overrides}
+        />
 
         <%= if @inner_block do %>
-          <div class={override_for(@socket, :slot_class)}>
+          <div class={override_for(@overrides, :slot_class)}>
             <%= render_slot(@inner_block) %>
           </div>
         <% end %>
@@ -114,7 +124,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
           strategy={@strategy}
           form={form}
           action={:sign_in}
-          disable_text={override_for(@socket, :disable_button_text)}
+          disable_text={override_for(@overrides, :disable_button_text)}
+          overrides={@overrides}
         />
       </.form>
     </div>

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -22,8 +22,13 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
   Children:
 
     * `AshAuthentication.Phoenix.Components.Strategy.Password`.
+    * `AshAuthentication.Phoenix.Components.Strategy.OAuth2`.
 
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
+
+  ## Props
+
+    * `overrides` - A list of override modules.
   """
 
   use Phoenix.LiveComponent
@@ -32,9 +37,13 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
   import AshAuthentication.Phoenix.Components.Helpers
   import Slug
 
+  @type props :: %{
+          optional(:overrides) => [module]
+        }
+
   @doc false
   @impl true
-  @spec update(Socket.assigns(), Socket.t()) :: {:ok, Socket.t()}
+  @spec update(props, Socket.t()) :: {:ok, Socket.t()}
   def update(assigns, socket) do
     strategies_by_resource =
       socket
@@ -53,6 +62,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       socket
       |> assign(assigns)
       |> assign(:strategies_by_resource, strategies_by_resource)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
 
     {:ok, socket}
   end
@@ -62,9 +72,14 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
   @spec render(Socket.assigns()) :: Rendered.t() | no_return
   def render(assigns) do
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
-      <%= if override_for(@socket, :show_banner, true) do %>
-        <.live_component module={Components.Banner} socket={@socket} id="sign-in-banner" />
+    <div class={override_for(@overrides, :root_class)}>
+      <%= if override_for(@overrides, :show_banner, true) do %>
+        <.live_component
+          module={Components.Banner}
+          socket={@socket}
+          id="sign-in-banner"
+          overrides={@overrides}
+        />
       <% end %>
 
       <%= for strategies <- @strategies_by_resource do %>
@@ -74,12 +89,13 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
               component={component_for_strategy(strategy)}
               strategy={strategy}
               socket={@socket}
+              overrides={@overrides}
             />
           <% end %>
         <% end %>
 
         <%= if Enum.any?(strategies.form) && Enum.any?(strategies.link) do %>
-          <.live_component module={Components.HorizontalRule} id="sign-in-hr" />
+          <.live_component module={Components.HorizontalRule} id="sign-in-hr" overrides={@overrides} />
         <% end %>
 
         <%= if Enum.any?(strategies.link) do %>
@@ -88,6 +104,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
               component={component_for_strategy(strategy)}
               strategy={strategy}
               socket={@socket}
+              overrides={@overrides}
             />
           <% end %>
         <% end %>
@@ -98,8 +115,13 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
   defp strategy(assigns) do
     ~H"""
-    <div class={override_for(@socket, :strategy_class)}>
-      <.live_component module={@component} id={strategy_id(@strategy)} strategy={@strategy} />
+    <div class={override_for(@overrides, :strategy_class)}>
+      <.live_component
+        module={@component}
+        id={strategy_id(@strategy)}
+        strategy={@strategy}
+        overrides={@overrides}
+      />
     </div>
     """
   end

--- a/lib/ash_authentication_phoenix/overrides.ex
+++ b/lib/ash_authentication_phoenix/overrides.ex
@@ -6,11 +6,11 @@ defmodule AshAuthentication.Phoenix.Overrides do
   which uses [TailwindCSS](https://tailwindcss.com/) to generate a fairly
   generic looking user interface.
 
-  You can override by setting the following in your `config.exs`:
+  You can override this by adding your own override modules to the
+  `AshAuthentication.Phoenix.Router.sign_in_route/3` macro in your router:
 
   ```elixir
-  config :my_app, AshAuthentication.Phoenix,
-    overrides: [MyAppWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+  sign_in_route overrides: [MyAppWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
   ```
 
   and defining `lib/my_app_web/auth_overrides.ex` within which you can set any
@@ -34,21 +34,6 @@ defmodule AshAuthentication.Phoenix.Overrides do
   end
   ```
   """
-
-  @doc """
-  Retrieve the override for a specific component and selector.
-  """
-  @spec override_for(otp_app :: atom, component :: module, selector :: atom) :: any
-  def override_for(otp_app, component, selector)
-      when is_atom(otp_app) and is_atom(component) and is_atom(selector) do
-    otp_app
-    |> Application.get_env(AshAuthentication.Phoenix, [])
-    |> Keyword.get(:overrides, [__MODULE__.Default])
-    |> Enum.find_value(fn module ->
-      module.overrides()
-      |> Map.get({component, selector})
-    end)
-  end
 
   @doc false
   @spec __using__(any) :: Macro.t()

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -43,7 +43,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
   override Components.Password do
     set :root_class, "mt-4 mb-4"
     set :interstitial_class, "flex flex-row justify-between content-between text-sm font-medium"
-    set :toggler_class, "flex-none text-blue-500 hover:text-blue-600"
+    set :toggler_class, "flex-none text-blue-500 hover:text-blue-600 px-2 first:pl-0 last:pr-0"
     set :sign_in_toggle_text, "Already have an account?"
     set :register_toggle_text, "Need an account?"
     set :reset_toggle_text, "Forgot your password?"

--- a/lib/ash_authentication_phoenix/sign_in_live.ex
+++ b/lib/ash_authentication_phoenix/sign_in_live.ex
@@ -24,11 +24,29 @@ defmodule AshAuthentication.Phoenix.SignInLive do
 
   @doc false
   @impl true
+  def mount(_params, session, socket) do
+    overrides =
+      session
+      |> Map.get("overrides", [AshAuthentication.Phoenix.Overrides.Default])
+
+    socket =
+      socket
+      |> assign(overrides: overrides)
+
+    {:ok, socket}
+  end
+
+  @doc false
+  @impl true
   @spec render(Socket.assigns()) :: Rendered.t()
   def render(assigns) do
     ~H"""
-    <div class={override_for(@socket, :root_class)}>
-      <.live_component module={Components.SignIn} id={override_for(@socket, :sign_in_id, "sign-in")} />
+    <div class={override_for(@overrides, :root_class)}>
+      <.live_component
+        module={Components.SignIn}
+        id={override_for(@overrides, :sign_in_id, "sign-in")}
+        overrides={@overrides}
+      />
     </div>
     """
   end


### PR DESCRIPTION
This means that if you are customising the default components you can remove the configuration from your `config.exs` and instead move it to your router.  This allows you to have multiple sign-in routes with different "themes" should that be necessary.