### PR TITLE
docs: fix `identity_field` in User example

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-authentication-phoenix.md
+++ b/documentation/tutorials/getting-started-with-ash-authentication-phoenix.md
@@ -224,7 +224,7 @@ defmodule Example.Accounts.User do
 
     strategies do
       password :password do
-        identity_field(:unique_email)
+        identity_field(:email)
       end
     end
 


### PR DESCRIPTION
I tried following this guide and kept running into this error
> The resource `Example.Accounts.User` does not define an attribute named `:unique_email`

After some fumbling around I discovered that the "Getting started with Ash Authentication" guide from Ash Authentication shows `identity_field :email` instead of `identity_field(:unique_email)` [here](https://github.com/team-alembic/ash_authentication/blob/eacda39a00d92c14032b64b40176855eeb82e0bc/documentation/tutorials/getting-started-with-authentication.md?plain=1#L180). With this small change the error stopped showing up and my code started to work.

Still very new to Ash so please let me know if I'm missing something.