### PR TITLE
improvement: Add slots to password-related forms.

### DIFF
--- a/dev/dev_web/live/custom_sign_in_live.ex
+++ b/dev/dev_web/live/custom_sign_in_live.ex
@@ -1,0 +1,73 @@
+defmodule DevWeb.CustomSignInLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  alias AshAuthentication.{Phoenix.Components.Password, Info}
+  alias Phoenix.LiveView.{Rendered, Socket}
+  import Phoenix.HTML.Form
+
+  @doc false
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign_new(:strategy, fn -> Info.strategy!(Example.Accounts.User, :password) end)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+
+    {:ok, socket}
+  end
+
+  @doc false
+  @impl true
+  @spec render(Socket.assigns()) :: Rendered.t() | no_return
+  def render(assigns) do
+    ~H"""
+    <div class="grid h-screen place-items-center dark:bg-gray-900">
+      <.live_component
+        module={Password}
+        strategy={@strategy}
+        id="custom-password"
+        socket={@socket}
+        overrides={@overrides}
+        class="mx-auth w-full max-w-sm lg:w-96"
+      >
+        <:sign_in_extra :let={form}>
+          <div class="mt-2 mb-2 dark:text-white">
+            <%= label(form, :capcha,
+              class: "block text-sm font-medium text-gray-700 mb-1 dark:text-white"
+            ) %>
+            <%= text_input(form, :capcha,
+              class:
+                "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-pale-500 focus:border-blue-pale-500 sm:text-sm dark:text-black"
+            ) %>
+          </div>
+        </:sign_in_extra>
+
+        <:register_extra :let={form}>
+          <div class="mt-2 mb-2 dark:text-white">
+            <%= label(form, :name,
+              class: "block text-sm font-medium text-gray-700 mb-1 dark:text-white"
+            ) %>
+            <%= text_input(form, :name,
+              class:
+                "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-pale-500 focus:border-blue-pale-500 sm:text-sm dark:text-black"
+            ) %>
+          </div>
+        </:register_extra>
+
+        <:reset_extra :let={form}>
+          <div class="mt-2 mb-2 dark:text-white">
+            <%= label(form, :capcha,
+              class: "block text-sm font-medium text-gray-700 mb-1 dark:text-white"
+            ) %>
+            <%= text_input(form, :capcha,
+              class:
+                "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-pale-500 focus:border-blue-pale-500 sm:text-sm dark:text-black"
+            ) %>
+          </div>
+        </:reset_extra>
+      </.live_component>
+    </div>
+    """
+  end
+end

--- a/dev/dev_web/live/home_page_live.ex
+++ b/dev/dev_web/live/home_page_live.ex
@@ -18,7 +18,9 @@ defmodule DevWeb.HomePageLive do
     <% else %>
       <h2>Please sign in</h2>
 
-      <.link navigate={Routes.auth_path(@socket, :sign_in)}>Sign in</.link>
+      <.link navigate={Routes.auth_path(@socket, :sign_in)}>Standard sign in</.link>
+      <br />
+      <.link navigate={Routes.live_path(@socket, DevWeb.CustomSignInLive)}>Custom sign in</.link>
     <% end %>
     """
   end

--- a/dev/dev_web/router.ex
+++ b/dev/dev_web/router.ex
@@ -23,6 +23,7 @@ defmodule DevWeb.Router do
 
     ash_authentication_live_session do
       live "/", HomePageLive
+      live "/custom-sign-in", CustomSignInLive
     end
   end
 

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -132,7 +132,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
 
         <%= if @inner_block do %>
           <div class={override_for(@overrides, :slot_class)}>
-            <%= render_slot(@inner_block) %>
+            <%= render_slot(@inner_block, form) %>
           </div>
         <% end %>
 

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -101,7 +101,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
 
         <%= if @inner_block do %>
           <div class={override_for(@overrides, :slot_class)}>
-            <%= render_slot(@inner_block) %>
+            <%= render_slot(@inner_block, form) %>
           </div>
         <% end %>
 

--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -116,7 +116,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
 
         <%= if @inner_block do %>
           <div class={override_for(@overrides, :slot_class)}>
-            <%= render_slot(@inner_block) %>
+            <%= render_slot(@inner_block, form) %>
           </div>
         <% end %>
 


### PR DESCRIPTION
Allows the sign in, register and reset forms to be customised by way of a named slot.

<img width="1124" alt="Screenshot 2023-03-22 at 4 38 51 PM" src="https://user-images.githubusercontent.com/59449/226796026-872f604d-824e-4b55-8955-79a0542dab62.png">
