### PR TITLE
fix: Overrides in reset route

### DIFF
--- a/lib/ash_authentication_phoenix/components/reset.ex
+++ b/lib/ash_authentication_phoenix/components/reset.ex
@@ -64,7 +64,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset do
     ~H"""
     <div class={override_for(@overrides, :root_class)}>
       <%= if override_for(@overrides, :show_banner, true) do %>
-        <.live_component module={Components.Banner} id="sign-in-banner" />
+        <.live_component module={Components.Banner} id="sign-in-banner" overrides={@overrides} />
       <% end %>
 
       <%= for strategy <- @strategies do %>


### PR DESCRIPTION
Overrides weren't getting added to the live session in the same way as `sign_in`, so this harmonizes implementations for the `sign_in` route macro with `reset_route` macro. It also passes a missing `@overrides` assigns to the Banner in the Reset component.