### PR TITLE
improvement: submit form in-line when sign_in_tokens_enabled

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -113,7 +113,7 @@ defmodule AshAuthentication.Phoenix.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ash_authentication, "~> 3.10"},
+      {:ash_authentication, "~> 3.11 and >= 3.11.9"},
       {:ash_phoenix, "~> 1.1"},
       {:ash, "~> 2.2"},
       {:jason, "~> 1.0"},


### PR DESCRIPTION
So, we might need to make this configurable, but based on my last comment here https://github.com/team-alembic/ash_authentication_phoenix/issues/269 I'm not sure it really matters. The responsibility for keeping bad actors out in this scenario would likely have to be in a plug or some kind of rate limiting logic. The "attacker" could use the fact that they got an error to suss out that they've hit on a username that exists anyway.
![CleanShot 2023-09-17 at 15 04 13@2x](https://github.com/team-alembic/ash_authentication_phoenix/assets/5722339/077c6337-66c7-4ece-b316-a02be5ea2e0d)
