### PR TITLE
improvement: optional support for routing to register & reset links

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-authentication-phoenix.md
+++ b/documentation/tutorials/getting-started-with-ash-authentication-phoenix.md
@@ -375,7 +375,9 @@ defmodule ExampleWeb.Router do
     get "/", PageController, :home
 
     # add these lines -->
-    sign_in_route()
+    # Leave out `register_path` and `reset_path` if you don't want to support
+    # user registration and/or password resets respectively.
+    sign_in_route(register_path: "/register", reset_path: "/reset")
     sign_out_route AuthController
     auth_routes_for Example.Accounts.User, to: AuthController
     reset_route []

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -42,7 +42,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
 
   @type props :: %{
           required(:strategy) => AshAuthentication.Strategy.t(),
-          optional(:overrides) => [module]
+          optional(:overrides) => [module],
+          optional(:live_action) => :sign_in | :register
         }
 
   @doc false

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -33,6 +33,10 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
     * `overrides` - A list of override modules.
     * `otp_app` - The otp app to look for authenticated resources in
+    * `live_action` - The live_action being routed to
+    * `path` - The path to use as the base for links
+    * `reset_path` - The path to use for reset links
+    * `register_path` - The path to use for register links
   """
 
   use Phoenix.LiveComponent
@@ -42,7 +46,10 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
   import Slug
 
   @type props :: %{
-          optional(:overrides) => [module]
+          optional(:overrides) => [module],
+          optional(:path) => String.t(),
+          optional(:reset_path) => String.t(),
+          optional(:register_path) => String.t()
         }
 
   @doc false
@@ -68,6 +75,10 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       socket
       |> assign(:strategies_by_resource, strategies_by_resource)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:live_action, fn -> :sign_in end)
+      |> assign_new(:path, fn -> "/" end)
+      |> assign_new(:reset_path, fn -> nil end)
+      |> assign_new(:register_path, fn -> nil end)
 
     {:ok, socket}
   end
@@ -87,7 +98,11 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
           <%= for strategy <- strategies.form do %>
             <.strategy
               component={component_for_strategy(strategy)}
+              live_action={@live_action}
               strategy={strategy}
+              path={@path}
+              reset_path={@reset_path}
+              register_path={@register_path}
               overrides={@overrides}
             />
           <% end %>
@@ -105,7 +120,11 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
           <%= for strategy <- strategies.link do %>
             <.strategy
               component={component_for_strategy(strategy)}
+              live_action={@live_action}
               strategy={strategy}
+              path={@path}
+              reset_path={@reset_path}
+              register_path={@register_path}
               overrides={@overrides}
             />
           <% end %>
@@ -122,6 +141,10 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
         module={@component}
         id={strategy_id(@strategy)}
         strategy={@strategy}
+        path={@path}
+        reset_path={@reset_path}
+        register_path={@register_path}
+        live_action={@live_action}
         overrides={@overrides}
       />
     </div>

--- a/lib/ash_authentication_phoenix/sign_in_live.ex
+++ b/lib/ash_authentication_phoenix/sign_in_live.ex
@@ -33,8 +33,16 @@ defmodule AshAuthentication.Phoenix.SignInLive do
       socket
       |> assign(overrides: overrides)
       |> assign_new(:otp_app, fn -> nil end)
+      |> assign(:path, session["path"] || "/")
+      |> assign(:reset_path, session["reset_path"])
+      |> assign(:register_path, session["register_path"])
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(_, _uri, socket) do
+    {:noreply, socket}
   end
 
   @doc false
@@ -46,6 +54,10 @@ defmodule AshAuthentication.Phoenix.SignInLive do
       <.live_component
         module={Components.SignIn}
         otp_app={@otp_app}
+        live_action={@live_action}
+        path={@path}
+        reset_path={@reset_path}
+        register_path={@register_path}
         id={override_for(@overrides, :sign_in_id, "sign-in")}
         overrides={@overrides}
       />


### PR DESCRIPTION
Fixes: #98 

This slightly special cases registration and reset. In the future we may want something more generic, but this is the only current case we have for strategy customizable links. Seemed simplest to do it this way for now.