### PR TITLE
Fix some copypasta in the sign_in_route/1 docstring

### DIFF
--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -130,7 +130,7 @@ defmodule AshAuthentication.Phoenix.Router do
   * `path` the path under which to mount the sign-in live-view. Defaults to `"/sign-in"`.
   * `register_path` - the path under which to mount the password strategy's registration live-view.
      If not set, and registration is supported, registration will use a dynamic toggle and will not be routeable to.
-  * `register_path` - the path under which to mount the password strategy's password reset live-view.
+  * `reset_path` - the path under which to mount the password strategy's password reset live-view.
     If not set, and password reset is supported, password reset will use a dynamic toggle and will not be routeable to.
   * `live_view` the name of the live view to render. Defaults to
     `AshAuthentication.Phoenix.SignInLive`.


### PR DESCRIPTION
The docstring contained the `register_path` parameter twice and forgot to include the `reset_path` parameter.