### PR TITLE
fix: incorrect introspection target in password strategy.

### DIFF
--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -97,7 +97,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
 
     subject_name =
       assigns.strategy.resource
-      |> Info.authentication_get_by_subject_action_name!()
+      |> Info.authentication_subject_name!()
       |> to_string()
       |> slugify()
 


### PR DESCRIPTION
We were using the `get_by_subject_action_name` instead of the `subject_name`.  Oops.

Fixes #108.