### PR TITLE
fix: Render flash messages and provide a default implementation

### DIFF
--- a/lib/ash_authentication_phoenix/components/banner.ex
+++ b/lib/ash_authentication_phoenix/components/banner.ex
@@ -23,7 +23,7 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias Phoenix.LiveView.Rendered
 
   @type props :: %{

--- a/lib/ash_authentication_phoenix/components/horizontal_rule.ex
+++ b/lib/ash_authentication_phoenix/components/horizontal_rule.ex
@@ -20,7 +20,7 @@ defmodule AshAuthentication.Phoenix.Components.HorizontalRule do
       * `overrides` - A list of override modules.
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias Phoenix.LiveView.Rendered
 
   @type props :: %{

--- a/lib/ash_authentication_phoenix/components/magic_link.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link.ex
@@ -29,7 +29,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components.Password.Input, Strategy}
   alias AshPhoenix.Form
   alias Phoenix.LiveView.{Rendered, Socket}
@@ -138,7 +138,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink do
     socket =
       if flash do
         socket
-        |> put_flash(:info, flash)
+        |> put_flash!(:info, flash)
       else
         socket
       end

--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -21,7 +21,7 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Strategy}
   alias Phoenix.LiveView.Rendered
   import AshAuthentication.Phoenix.Components.Helpers, only: [route_helpers: 1]

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -73,7 +73,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components.Password, Strategy}
   alias Phoenix.LiveView.{JS, Rendered, Socket}
   import Slug

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -24,7 +24,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.Component
+  use AshAuthentication.Phoenix.Web, :component
   alias AshAuthentication.Strategy
   alias AshPhoenix.Form
   alias Phoenix.LiveView.{Rendered, Socket}

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -30,7 +30,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
 
   alias AshAuthentication.{Info, Phoenix.Components.Password.Input, Strategy}
   alias AshPhoenix.Form

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -32,7 +32,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
 
   alias AshAuthentication.{Info, Phoenix.Components.Password.Input, Strategy}
 
@@ -151,7 +151,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
     socket =
       if flash do
         socket
-        |> put_flash(:info, flash)
+        |> put_flash!(:info, flash)
       else
         socket
       end

--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -31,7 +31,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components.Password, Strategy}
   alias AshPhoenix.Form
   alias Phoenix.LiveView.{Rendered, Socket}

--- a/lib/ash_authentication_phoenix/components/reset.ex
+++ b/lib/ash_authentication_phoenix/components/reset.ex
@@ -24,7 +24,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components, Strategy.Password}
   alias Phoenix.LiveView.{Rendered, Socket}
   import AshAuthentication.Phoenix.Components.Helpers

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -34,7 +34,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components.Password.Input, Strategy}
   alias AshPhoenix.Form
   alias Phoenix.LiveView.{Rendered, Socket}

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -39,7 +39,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
     * `register_path` - The path to use for register links
   """
 
-  use Phoenix.LiveComponent
+  use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Phoenix.Components, Strategy}
   alias Phoenix.LiveView.{Rendered, Socket}
   import AshAuthentication.Phoenix.Components.Helpers

--- a/lib/ash_authentication_phoenix/reset_live.ex
+++ b/lib/ash_authentication_phoenix/reset_live.ex
@@ -16,7 +16,7 @@ defmodule AshAuthentication.Phoenix.ResetLive do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveView
+  use AshAuthentication.Phoenix.Web, :live_view
   alias AshAuthentication.Phoenix.Components
   alias Phoenix.LiveView.{Rendered, Socket}
 

--- a/lib/ash_authentication_phoenix/sign_in_live.ex
+++ b/lib/ash_authentication_phoenix/sign_in_live.ex
@@ -18,7 +18,7 @@ defmodule AshAuthentication.Phoenix.SignInLive do
   #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
   """
 
-  use Phoenix.LiveView
+  use AshAuthentication.Phoenix.Web, :live_view
   alias AshAuthentication.Phoenix.Components
   alias Phoenix.LiveView.{Rendered, Socket}
 

--- a/lib/ash_authentication_phoenix/templates/live.html.heex
+++ b/lib/ash_authentication_phoenix/templates/live.html.heex
@@ -1,0 +1,13 @@
+<%= if live_flash(@flash, :info) do %>
+  <p role="alert" phx-click="lv:clear-flash" phx-value-key="info">
+    <%= live_flash(@flash, :info) %>
+  </p>
+<% end %>
+
+<%= if live_flash(@flash, :error) do %>
+  <p role="alert" phx-click="lv:clear-flash" phx-value-key="error">
+    <%= live_flash(@flash, :error) %>
+  </p>
+<% end %>
+
+<%= @inner_content %>

--- a/lib/ash_authentication_phoenix/templates/live.html.heex
+++ b/lib/ash_authentication_phoenix/templates/live.html.heex
@@ -1,11 +1,23 @@
 <%= if live_flash(@flash, :info) do %>
-  <p role="alert" phx-click="lv:clear-flash" phx-value-key="info">
+  <p
+    class="fixed top-2 right-2 mr-2 w-80 sm:w-96 z-50 rounded-lg p-3 text-sm
+           bg-emerald-100 dark:bg-emerald-200 text-emerald-800"
+    role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="info"
+  >
     <%= live_flash(@flash, :info) %>
   </p>
 <% end %>
 
 <%= if live_flash(@flash, :error) do %>
-  <p role="alert" phx-click="lv:clear-flash" phx-value-key="error">
+  <p
+    class="fixed top-2 right-2 mr-2 w-80 sm:w-96 z-50 rounded-lg p-3 text-sm
+           bg-rose-100 dark:bg-rose-200 text-rose-900"
+    role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="error"
+  >
     <%= live_flash(@flash, :error) %>
   </p>
 <% end %>

--- a/lib/ash_authentication_phoenix/utils/flash.ex
+++ b/lib/ash_authentication_phoenix/utils/flash.ex
@@ -1,0 +1,25 @@
+defmodule AshAuthentication.Phoenix.Utils.Flash do
+  import Phoenix.LiveView
+
+  @doc """
+  Attach a hook to receive flash messages sent from components, for rendering in
+  the top-level liveview.
+  """
+  def on_mount(_name, _params, _session, socket) do
+    {:cont, attach_hook(socket, :flash, :handle_info, &maybe_receive_flash/2)}
+  end
+
+  defp maybe_receive_flash({:put_flash, type, message}, socket) do
+    {:halt, put_flash(socket, type, message)}
+  end
+
+  defp maybe_receive_flash(_, socket), do: {:cont, socket}
+
+  @doc """
+  Send flash messages from components, to be rendered in their parent liveview.
+  """
+  def put_flash!(socket, type, message) do
+    send(self(), {:put_flash, type, message})
+    socket
+  end
+end

--- a/lib/ash_authentication_phoenix/utils/flash.ex
+++ b/lib/ash_authentication_phoenix/utils/flash.ex
@@ -1,4 +1,8 @@
 defmodule AshAuthentication.Phoenix.Utils.Flash do
+  @moduledoc """
+  Utility functions for sending and receiving flash messages.
+  """
+
   import Phoenix.LiveView
 
   @doc """

--- a/lib/ash_authentication_phoenix/views/layout_view.ex
+++ b/lib/ash_authentication_phoenix/views/layout_view.ex
@@ -1,0 +1,5 @@
+defmodule AshAuthentication.Phoenix.LayoutView do
+  @moduledoc false
+
+  use AshAuthentication.Phoenix.Web, :view
+end

--- a/lib/ash_authentication_phoenix_web.ex
+++ b/lib/ash_authentication_phoenix_web.ex
@@ -1,0 +1,49 @@
+defmodule AshAuthentication.Phoenix.Web do
+  alias AshAuthentication.Phoenix.{LayoutView, Utils.Flash, Web}
+
+  @doc false
+  def view do
+    quote do
+      use Phoenix.View,
+        root: "lib/ash_authentication_phoenix/templates",
+        namespace: Web
+
+      # Import convenience functions from controllers
+      import Phoenix.Controller,
+        only: [view_module: 1, view_template: 1]
+
+      use Phoenix.Component
+    end
+  end
+
+  @doc false
+  def live_view do
+    quote do
+      use Phoenix.LiveView, layout: {LayoutView, :live}
+      on_mount Flash
+    end
+  end
+
+  @doc false
+  def live_component do
+    quote do
+      use Phoenix.LiveComponent
+      import Flash, only: [put_flash!: 3]
+    end
+  end
+
+  @doc false
+  def component do
+    quote do
+      use Phoenix.Component
+      import Flash, only: [put_flash!: 3]
+    end
+  end
+
+  @doc """
+  When used, dispatch to the appropriate controller/view/etc.
+  """
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/lib/ash_authentication_phoenix_web.ex
+++ b/lib/ash_authentication_phoenix_web.ex
@@ -1,4 +1,6 @@
 defmodule AshAuthentication.Phoenix.Web do
+  @moduledoc false
+
   alias AshAuthentication.Phoenix.{LayoutView, Utils.Flash, Web}
 
   @doc false


### PR DESCRIPTION
**The Issue**

Flash messages not being rendered in scenarios like submitting the reset password form, telling the user that the request has been received.

**The Reason**

There are actually two reasons:

1) Our liveviews are rendering inside the root layout of the parent app, but the main layout (eg. `live` or `app`) was not being set.
A fresh generated Phoenix app [has the flash messags within those layouts](https://github.com/team-alembic/ash_authentication_phoenix/blob/main/dev/dev_web/templates/layout/live.html.heex), and defines the layout to use [when using the Phoenix.LiveView macro](https://github.com/team-alembic/ash_authentication_phoenix/blob/main/dev/dev_web.ex#L49-L50).
So now our liveviews do the same. Instead of using Phoenix.LiveView, with no layout configured, they use AshAuthentication.Phoenix.Web, which has a default layout configured which displays nice flash messages.

2) Flash messages were being set from live components, which do not propagate to their parent liveview for rendering. ([I wrote a blog post on this a few months ago.](https://sevenseacat.net/posts/2023/flash-messages-in-phoenix-liveview-components/)).

**The Result**

With both of those issues fixed, now flash messages are rendered when appropriate: 

https://github.com/team-alembic/ash_authentication_phoenix/assets/543859/5f6cd94a-f6c8-443d-bfe5-7b3e3ca8bbd0

**Other Notes**

If users have their own layout they want to use, it can be provided when defining routes, eg.

```elixir
sign_in_route(
  overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default], 
  layout: {DevWeb.LayoutView, :live}
)
```

And it will be used instead of our default one. I feel like that should be documented somewhere, but I'm not sure exactly where.