### PR TITLE
docs: change tutorial to help enable policy authorizers

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -33,7 +33,8 @@ defmodule Example.MixProject do
       {:ash, "~> x.x"},
       {:ash_authentication, "~> x.x"},
       {:ash_authentication_phoenix, "~> x.x"},
-      {:ash_postgres, "~> x.x"}
+      {:ash_postgres, "~> x.x"},
+      {:picosat_elixir, "~> x.x"}
       # <-- add these lines
     ]
   end
@@ -45,6 +46,10 @@ Let's fetch everything:
 ```bash
 $ mix deps.get
 ```
+
+> ### Picosat installation issues? {: .info}
+>
+> Replace `{:picosat_elixir, "~> x.x"}` with `{:simple_sat, "~> x.x"}` to use a simpler (but mildly slower) solver. You can always switch back to `picosat_elixir` later once you're done with the tutorial.
 
 ### Formatter
 

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -212,6 +212,8 @@ defmodule Example.Accounts.User do
   use Ash.Resource,
     domain: Example.Accounts,
     data_layer: AshPostgres.DataLayer,
+    # If using policies, enable the policy authorizer:
+    # authorizers: [Ash.Policy.Authorizer],
     extensions: [AshAuthentication]
 
   attributes do
@@ -281,6 +283,8 @@ defmodule Example.Accounts.Token do
   use Ash.Resource,
     domain: Example.Accounts,
     data_layer: AshPostgres.DataLayer,
+    # If using policies, enable the policy authorizer:
+    # authorizers: [Ash.Policy.Authorizer],
     extensions: [AshAuthentication.TokenResource]
 
   postgres do

--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -49,7 +49,7 @@ $ mix deps.get
 
 > ### Picosat installation issues? {: .info}
 >
-> Replace `{:picosat_elixir, "~> x.x"}` with `{:simple_sat, "~> x.x"}` to use a simpler (but mildly slower) solver. You can always switch back to `picosat_elixir` later once you're done with the tutorial.
+> If you have trouble compiling `picosat_elixir`, then replace `{:picosat_elixir, "~> x.x"}` with `{:simple_sat, "~> x.x"}` to use a simpler (but mildly slower) solver. You can always switch back to `picosat_elixir` later once you're done with the tutorial.
 
 ### Formatter
 


### PR DESCRIPTION
This pull request fixes issues with the policy authorizer setup instructions in the tutorial.

The first commit adds a missing import to a couple sections. The second commit adds instructions for adding the `picosat_elixir` solver. The content for the second pull request was taken from the main Ash tutorial.