### PR TITLE
fix: Ensure session respects router scope when using sign_in_route helper

### DIFF
--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -189,9 +189,9 @@ defmodule AshAuthentication.Phoenix.Router do
                %{
                  "overrides" => unquote(overrides),
                  "otp_app" => unquote(otp_app),
-                 "path" => unquote(path),
-                 "reset_path" => unquote(reset_path),
-                 "register_path" => unquote(register_path)
+                 "path" => Phoenix.Router.scoped_path(__MODULE__, unquote(path)),
+                 "reset_path" => Phoenix.Router.scoped_path(__MODULE__, unquote(reset_path)),
+                 "register_path" => Phoenix.Router.scoped_path(__MODULE__, unquote(register_path))
                }
              ]},
           on_mount: on_mount


### PR DESCRIPTION
This fixes #489 by ensuring that the session options reflect the scoped path by using ```Phoenix.Router.scoped``` rather than just the literal string path passed into the helper.