### PR TITLE
fix: Re-link form labels and form inputs on Password strategy forms

### DIFF
--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -86,7 +86,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     ~H"""
     <div class={override_for(@overrides, :field_class)}>
-      <%= label(@form, override_for(@overrides, :identity_input_label),
+      <%= label(@form, @identity_field, override_for(@overrides, :identity_input_label),
         class: override_for(@overrides, :label_class)
       ) %>
       <%= text_input(@form, @identity_field,
@@ -138,7 +138,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     ~H"""
     <div class={override_for(@overrides, :field_class)}>
-      <%= label(@form, override_for(@overrides, :password_input_label),
+      <%= label(@form, @password_field, override_for(@overrides, :password_input_label),
         class: override_for(@overrides, :label_class)
       ) %>
       <%= password_input(@form, @password_field,
@@ -189,7 +189,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     ~H"""
     <div class={override_for(@overrides, :field_class)}>
-      <%= label(@form, override_for(@overrides, :password_input_label),
+      <%= label(@form, @password_confirmation_field, override_for(@overrides, :password_input_label),
         class: override_for(@overrides, :label_class)
       ) %>
       <%= password_input(@form, @password_confirmation_field,

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -3,8 +3,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     field_class: "CSS class for `div` elements surrounding the fields.",
     label_class: "CSS class for `label` elements.",
     input_class: "CSS class for text/password `input` elements.",
-    identity_input_label: "Label for identity (email) field.",
+    identity_input_label: "Label for identity field.",
     password_input_label: "Label for password field.",
+    password_confirmation_input_label: "Label for password confirmation field.",
     input_class_with_error:
       "CSS class for text/password `input` elements when there is a validation error.",
     submit_class: "CSS class for the form submit `input` element.",
@@ -189,7 +190,10 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     ~H"""
     <div class={override_for(@overrides, :field_class)}>
-      <%= label(@form, @password_confirmation_field, override_for(@overrides, :password_input_label),
+      <%= label(
+        @form,
+        @password_confirmation_field,
+        override_for(@overrides, :password_confirmation_input_label),
         class: override_for(@overrides, :label_class)
       ) %>
       <%= password_input(@form, @password_confirmation_field,

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -143,6 +143,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     """
 
     set :password_input_label, "Password"
+    set :password_confirmation_input_label, "Password Confirmation"
     set :identity_input_label, "Email"
     set :error_ul, "text-red-400 font-light my-3 italic text-sm"
     set :error_li, nil


### PR DESCRIPTION
Using the same name for the labels and fields allows the fields to be focussed by clicking on the label.

Also fixed a quirk where the same label key was used for both Password and Password confirmation fields.