### PR TITLE
fix: Apply overrides to password reset update form in Igniter-generated routes

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -119,7 +119,7 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.Install do
           overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
 
         # Remove this if you do not want to use the reset password feature
-        reset_route auth_routes_prefix: "/auth"
+        reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
         """,
         with_pipelines: [:browser],
         arg2: Igniter.Libs.Phoenix.web_module(igniter),

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -202,7 +202,10 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     + |    )
     + |
     + |    # Remove this if you do not want to use the reset password feature
-    + |    reset_route(auth_routes_prefix: "/auth")
+    + |    reset_route(
+    + |      auth_routes_prefix: "/auth",
+    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+    + |    )
     + |  end
     """)
   end


### PR DESCRIPTION
Without this, only the default override values are used!