### PR TITLE
chore: Tweak UI styling

### DIFF
--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -235,6 +235,13 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:label, fn ->
         case assigns.action do
+          :reset ->
+            assigns.strategy.resettable
+            |> Kernel.||(%{})
+            |> Map.get(:password_reset_action_name, :reset)
+            |> to_string()
+            |> String.trim_trailing("_with_password")
+
           :request_reset ->
             assigns.strategy.resettable
             |> Kernel.||(%{})

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -133,7 +133,6 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
           form={form}
           action={:reset}
           disable_text={override_for(@overrides, :disable_button_text)}
-          label={humanize(@resettable.password_reset_action_name)}
           overrides={@overrides}
         />
       </.form>

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -178,7 +178,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
   defp strategy_style(%AshAuthentication.AddOn.Confirmation{}), do: nil
   defp strategy_style(%Strategy.Password{}), do: :form
-  defp strategy_style(%Strategy.MagicLink{}), do: :form
+  defp strategy_style(%Strategy.MagicLink{}), do: :link
   defp strategy_style(_), do: :link
 
   defp component_for_strategy(%{strategy_module: Strategy.Apple}), do: Components.Apple


### PR DESCRIPTION
Some small tweaks, for:

Positioning of the Magic Link form

| Before | After |
| ------- | ------ |
| <img width="446" alt="Screenshot 2024-11-12 at 12 14 02 PM" src="https://github.com/user-attachments/assets/7dbfa2a8-d90e-429d-899e-677e70d0c91d"> | <img width="471" alt="Screenshot 2024-11-12 at 12 17 45 PM" src="https://github.com/user-attachments/assets/9300a214-ca96-42f1-a13b-161b5de58f07"> |

Text for Password Reset button

| Before | After | 
| ------- | ------ |
| <img width="446" alt="Screenshot 2024-11-12 at 12 18 15 PM" src="https://github.com/user-attachments/assets/8f342eef-e793-44c9-8870-7ab2ad1f35ec"> | <img width="436" alt="Screenshot 2024-11-12 at 12 18 00 PM" src="https://github.com/user-attachments/assets/b39379c5-a967-4bca-a005-57241764e9b1"> |
