### PR TITLE
feat: Add action-specific flash messages to the generated AuthController

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -252,14 +252,22 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.Install do
       use #{inspect(Igniter.Libs.Phoenix.web_module(igniter))}, :controller
       use AshAuthentication.Phoenix.Controller
 
-      def success(conn, _activity, user, _token) do
+      def success(conn, activity, user, _token) do
         return_to = get_session(conn, :return_to) || ~p"/"
+
+        message =
+          case activity do
+            {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
+            {:password, :reset} -> "Your password has successfully been reset"
+            _ -> "You are now signed in"
+          end
 
         conn
         |> delete_session(:return_to)
         |> store_in_session(user)
         # If your resource has a different name, update the assign name here (i.e :current_admin)
         |> assign(:current_user, user)
+        |> put_flash(:info, message)
         |> redirect(to: return_to)
       end
 
@@ -274,6 +282,7 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.Install do
 
         conn
         |> clear_session()
+        |> put_flash(:info, "You are now signed out")
         |> redirect(to: return_to)
       end
       """

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -87,14 +87,22 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
       use TestWeb, :controller
       use AshAuthentication.Phoenix.Controller
 
-      def success(conn, _activity, user, _token) do
+      def success(conn, activity, user, _token) do
         return_to = get_session(conn, :return_to) || ~p"/"
+
+        message =
+          case activity do
+            {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
+            {:password, :reset} -> "Your password has successfully been reset"
+            _ -> "You are now signed in"
+          end
 
         conn
         |> delete_session(:return_to)
         |> store_in_session(user)
         # If your resource has a different name, update the assign name here (i.e :current_admin)
         |> assign(:current_user, user)
+        |> put_flash(:info, message)
         |> redirect(to: return_to)
       end
 
@@ -109,6 +117,7 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
 
         conn
         |> clear_session()
+        |> put_flash(:info, "You are now signed out")
         |> redirect(to: return_to)
       end
     end


### PR DESCRIPTION
It's kind of a lame user experience that there are no flash messages by default for things like login, confirm password, etc. This adds some reasonable enough defaults, so that new users running `ash_authentication_phoenix.install` get some in their AuthController.

Note that there isn't currently a way to distinguish between sign in/register using the activity, as it's `{:password, :sign_in_with_token}` for both due to LiveView shenanigans.