### PR TITLE
fix: handle tenant-specific query in Password Reset Form handle_event/3

### DIFF
--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -152,6 +152,10 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
         changeset when is_struct(changeset, Ash.Changeset) ->
           changeset
           |> Ash.Changeset.set_tenant(socket.assigns.current_tenant)
+
+        query when is_struct(query, Ash.Query) ->
+          query
+          |> Ash.Query.set_tenant(socket.assigns.current_tenant)
       end
     )
 


### PR DESCRIPTION
- Added logic to set the current tenant on the `Ash.Query` in `handle_event/3` for the `Password.ResetForm` component.
- Fixes `FunctionClauseError` caused by unmatched query structures during password reset events.

Fixed Error screenshot
![image](https://github.com/user-attachments/assets/505e95cc-748e-42b0-a6d1-61b1eb694f44)
