### PR TITLE
feat: Add override for identity input placeholder

### DIFF
--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -4,6 +4,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     label_class: "CSS class for `label` elements.",
     input_class: "CSS class for text/password `input` elements.",
     identity_input_label: "Label for identity field.",
+    identity_input_placeholder: "Placeholder for identity field.",
     password_input_label: "Label for password field.",
     password_confirmation_input_label: "Label for password confirmation field.",
     input_class_with_error:
@@ -94,7 +95,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
         type: to_string(@input_type),
         class: @input_class,
         phx_debounce: override_for(@overrides, :input_debounce),
-        autofocus: "true"
+        autofocus: "true",
+        placeholder: override_for(@overrides, :identity_input_placeholder)
       ) %>
       <.error form={@form} field={@identity_field} overrides={@overrides} />
     </div>

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -145,6 +145,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     set :password_input_label, "Password"
     set :password_confirmation_input_label, "Password Confirmation"
     set :identity_input_label, "Email"
+    set :identity_input_placeholder, nil
     set :error_ul, "text-red-400 font-light my-3 italic text-sm"
     set :error_li, nil
     set :input_debounce, 350


### PR DESCRIPTION
What it says on the tin. Just needed to set the placeholder value for the strategy input.