### PR TITLE
Set the expected message in failure function.

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -290,7 +290,7 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.Install do
           end
 
         conn
-        |> put_flash(:error, "Incorrect email or password")
+        |> put_flash(:error, message)
         |> redirect(to: ~p"/sign-in")
       end
 


### PR DESCRIPTION
The generated `auth_controller.ex` file contains a small error. The message in the `failure` function is not used.

This PR uses the proper message.