### PR TITLE
Gettext components fix

### DIFF
--- a/lib/ash_authentication_phoenix/components/apple.ex
+++ b/lib/ash_authentication_phoenix/components/apple.ex
@@ -42,6 +42,7 @@ defmodule AshAuthentication.Phoenix.Components.Apple do
       assigns
       |> assign(:subject_name, Info.authentication_subject_name!(assigns.strategy.resource))
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
 
     ~H"""
     <div class={override_for(@overrides, :root_class)}>

--- a/lib/ash_authentication_phoenix/components/banner.ex
+++ b/lib/ash_authentication_phoenix/components/banner.ex
@@ -38,6 +38,7 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
     assigns =
       assigns
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
 
     ~H"""
     <div class={override_for(@overrides, :root_class)}>

--- a/lib/ash_authentication_phoenix/components/magic_link.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link.ex
@@ -59,6 +59,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink do
       |> assign(assigns)
       |> assign(trigger_action: false, subject_name: subject_name)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:label, fn -> nil end)
       |> assign_new(:current_tenant, fn -> nil end)
       |> assign_new(:context, fn -> %{} end)

--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -44,6 +44,7 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
       assigns
       |> assign(:subject_name, Info.authentication_subject_name!(assigns.strategy.resource))
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)
 
     ~H"""

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -141,6 +141,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
       |> assign(:sign_in_enabled?, !is_nil(override_for(assigns.overrides, :sign_in_toggle_text)))
       |> assign(:reset_id, reset_id)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:live_action, fn -> :sign_in end)
       |> assign_new(:path, fn -> "/" end)
       |> assign_new(:reset_path, fn -> nil end)

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -66,11 +66,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     assigns =
       assigns
-      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
-
-    assigns =
-      assigns
       |> assign(:identity_field, identity_field)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:input_type, fn ->
         identity_field
         |> to_string()
@@ -130,11 +128,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     assigns =
       assigns
-      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
-
-    assigns =
-      assigns
       |> assign(:password_field, password_field)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:input_class, fn ->
         if has_error?(assigns.form, password_field) do
           override_for(assigns.overrides, :input_class_with_error)
@@ -183,11 +179,9 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
 
     assigns =
       assigns
-      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
-
-    assigns =
-      assigns
       |> assign(:password_confirmation_field, password_confirmation_field)
+      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:input_class, fn ->
         if has_error?(assigns.form, password_confirmation_field) do
           override_for(assigns.overrides, :input_class_with_error)
@@ -243,6 +237,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     assigns =
       assigns
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:label, fn ->
         case assigns.action do
           :reset ->
@@ -308,6 +303,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     assigns =
       assigns
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:errors, fn ->
         assigns.form
         |> Form.errors()

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -224,7 +224,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     * `strategy` - The configuration map as per
       `AshAuthentication.authenticated_resources/1`.  Required.
     * `form` - An `AshPhoenix.Form`.  Required.
-    * `action` - Either `:sign_in` or `:register`.  Required.
+    * `action` - Either `:sign_in`, `:register`, `:request_reset` or `:reset`.  Required.
     * `label` - The text to show in the submit label.  Generated from the
       configured action name (via `Phoenix.Naming.humanize/1`) if not supplied.
     * `overrides` - A list of override modules.
@@ -234,7 +234,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
           required(:socket) => Socket.t(),
           required(:strategy) => Strategy.t(),
           required(:form) => Form.t(),
-          required(:action) => :sign_in | :register,
+          required(:action) => :sign_in | :register | :request_reset | :reset,
           optional(:label) => String.t(),
           optional(:overrides) => [module],
           optional(:gettext_fn) => {module, atom}

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -83,6 +83,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
       |> assign_new(:label, fn -> humanize(strategy.register_action_name) end)
       |> assign_new(:inner_block, fn -> nil end)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:current_tenant, fn -> nil end)
       |> assign_new(:context, fn -> %{} end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -67,6 +67,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
       |> assign_new(:label, fn -> strategy.request_password_reset_action_name end)
       |> assign_new(:inner_block, fn -> nil end)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:current_tenant, fn -> nil end)
       |> assign_new(:context, fn -> nil end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)

--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -85,6 +85,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
       |> assign_new(:label, fn -> humanize(strategy.sign_in_action_name) end)
       |> assign_new(:inner_block, fn -> nil end)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:current_tenant, fn -> nil end)
       |> assign_new(:context, fn -> %{} end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)

--- a/lib/ash_authentication_phoenix/components/reset.ex
+++ b/lib/ash_authentication_phoenix/components/reset.ex
@@ -55,6 +55,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset do
       socket
       |> assign(strategies: strategies)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)
 
     {:ok, socket}

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -86,6 +86,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
       )
       |> assign_new(:label, fn -> humanize(resettable.password_reset_action_name) end)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)
 
     {:ok, socket}

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -79,6 +79,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       socket
       |> assign(:strategies_by_resource, strategies_by_resource)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+      |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:live_action, fn -> :sign_in end)
       |> assign_new(:path, fn -> "/" end)
       |> assign_new(:reset_path, fn -> nil end)

--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -346,7 +346,7 @@ defmodule AshAuthentication.Phoenix.Router do
 
   @doc """
   Generates a generic, white-label password reset page using LiveView and the components in
-  `AshAuthentication.Phoenix.Components`. This is the page that allows a user to actually change his passowrd,
+  `AshAuthentication.Phoenix.Components`. This is the page that allows a user to actually change his password,
   after requesting a reset token via the sign-in (`/reset`) route.
 
   Available options are:

--- a/test/components_test.exs
+++ b/test/components_test.exs
@@ -1,0 +1,25 @@
+defmodule AshAuthentication.Phoenix.ComponentsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  @endpoint AshAuthentication.Phoenix.Test.Endpoint
+
+  setup do
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  test "custom liveview renders the sign in page", %{conn: conn} do
+    conn = get(conn, "/custom_lv")
+    assert {:ok, view, _html} = live(conn)
+
+    assert element(
+             view,
+             "div#user-password-sign-in-with-password-wrapper:not(.hidden)",
+             "Sign in"
+           )
+           |> render()
+  end
+end

--- a/test/password_reset_test.exs
+++ b/test/password_reset_test.exs
@@ -12,6 +12,18 @@ defmodule AshAuthentication.Phoenix.PasswordResetTest do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 
+  test "sign_in routes liveview renders the request password reset page", %{conn: conn} do
+    conn = get(conn, "/reset")
+    assert {:ok, view, _html} = live(conn)
+
+    assert element(
+             view,
+             "div#user-password-request-password-reset-with-password-wrapper:not(.hidden)",
+             "Request reset password link"
+           )
+           |> render()
+  end
+
   test "reset_route routes liveview renders the password reset page", %{conn: conn} do
     conn = get(conn, "/password-reset/my_token_213")
     assert {:ok, _view, html} = live(conn)
@@ -32,5 +44,65 @@ defmodule AshAuthentication.Phoenix.PasswordResetTest do
     assert {:ok, _view, html} = live(conn)
     refute html =~ "Password reset"
     assert html =~ "ever gonna"
+  end
+
+  test "full password reset via sign_in and reset routes", %{conn: conn} do
+    Example.Accounts.User
+    |> Ash.Changeset.for_create(:register_with_password, %{
+      email: "steffen@example.com",
+      password: "so-secure!",
+      password_confirmation: "so-secure!"
+    })
+    |> Ash.create!()
+
+    assert_received(
+      :sender_password_confirmation_fired,
+      "user registration did not send confirmation email"
+    )
+
+    conn = get(conn, "/reset")
+    assert {:ok, lv, _html} = live(conn)
+
+    lv
+    |> form("#user-password-request-password-reset-with-password-wrapper form", %{
+      "user" => %{
+        "email" => "steffen@example.com"
+      }
+    })
+    |> render_submit()
+
+    assert_received(
+      {:sender_password_reset_request_fired, token},
+      "request password reset action did not send email"
+    )
+
+    # Render again to process flash messages from components
+    html = lv |> render()
+    assert html =~ "reset instructions"
+
+    conn = get(conn, "/password-reset/#{token}")
+    assert {:ok, lv, _html} = live(conn)
+
+    reset_form_data = %{
+      "user" => %{
+        "reset_token" => token,
+        "password" => "much secret",
+        "password_confirmation" => "much secret"
+      }
+    }
+
+    # Submit once to validate and have `phx-trigger-action` activated
+    lv
+    |> form("form", reset_form_data)
+    |> render_submit()
+
+    conn =
+      lv
+      |> form("form", reset_form_data)
+      |> follow_trigger_action(conn)
+
+    refute conn.assigns[:failure_reason]
+    assert conn.resp_body =~ "Success"
+    assert conn.assigns[:current_user], "user not logged in after password change"
   end
 end

--- a/test/sign_in_test.exs
+++ b/test/sign_in_test.exs
@@ -15,8 +15,14 @@ defmodule AshAuthentication.Phoenix.SignInTest do
 
   test "sign_in routes liveview renders the sign in page", %{conn: conn} do
     conn = get(conn, "/sign-in")
-    assert {:ok, _view, html} = live(conn)
-    assert html =~ "Sign in"
+    assert {:ok, view, _html} = live(conn)
+
+    assert element(
+             view,
+             "div#user-password-sign-in-with-password-wrapper:not(.hidden)",
+             "Sign in"
+           )
+           |> render()
   end
 
   test "sign_in routes allow a user to sign in", %{conn: conn} do

--- a/test/support/accounts/user.ex
+++ b/test/support/accounts/user.ex
@@ -7,6 +7,7 @@ defmodule Example.Accounts.User do
 
   require Logger
   alias Ash.Error.Query.InvalidArgument
+  alias AshAuthentication.Phoenix.Test.Helper
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
@@ -101,6 +102,7 @@ defmodule Example.Accounts.User do
 
         sender(fn user, token, _ ->
           Logger.debug("Confirmation request for #{user.email} with token #{inspect(token)}")
+          Helper.notify_test(:sender_password_confirmation_fired)
         end)
       end
     end
@@ -115,6 +117,7 @@ defmodule Example.Accounts.User do
         resettable do
           sender(fn user, token, _ ->
             Logger.debug("Password reset request for #{user.email} with token #{inspect(token)}")
+            Helper.notify_test({:sender_password_reset_request_fired, token})
           end)
         end
       end

--- a/test/support/components_live.ex
+++ b/test/support/components_live.ex
@@ -1,0 +1,22 @@
+defmodule AshAuthentication.Phoenix.Test.ComponentsLive do
+  @moduledoc false
+  use Phoenix.LiveView, layout: {AshAuthentication.Phoenix.Test.HomeLive, :live}
+  alias AshAuthentication.Phoenix.Components
+
+  @impl true
+  def mount(_params, session, socket) do
+    socket =
+      socket
+      |> assign(:auth_routes_prefix, session["auth_routes_prefix"])
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <%!-- Sign-in component with minimal attributes --%>
+    <.live_component module={Components.SignIn} id="sign-in" auth_routes_prefix={@auth_routes_prefix} />
+    """
+  end
+end

--- a/test/support/helper.ex
+++ b/test/support/helper.ex
@@ -1,0 +1,14 @@
+defmodule AshAuthentication.Phoenix.Test.Helper do
+  @moduledoc false
+
+  @doc "Send message to original test (to simulate user/email interaction)"
+  # copied from Swoosh
+  def notify_test(message) do
+    pids =
+      Enum.uniq([self() | List.wrap(Process.get(:"$callers"))])
+
+    for pid <- pids do
+      send(pid, message)
+    end
+  end
+end

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -57,6 +57,7 @@ end
 
 defmodule AshAuthentication.Phoenix.Test.Router do
   @moduledoc false
+  alias AshAuthentication.Phoenix.Test.ComponentsLive
   use Phoenix.Router
   import Phoenix.LiveView.Router
   use AshAuthentication.Phoenix.Router
@@ -79,6 +80,12 @@ defmodule AshAuthentication.Phoenix.Test.Router do
     sign_out_route AuthController
     reset_route auth_routes_prefix: "/auth"
     auth_routes AuthController, Example.Accounts.User, path: "/auth"
+
+    # Custom LiveView for components testing
+    sign_in_route path: "/custom_lv",
+                  auth_routes_prefix: "/auth",
+                  live_view: ComponentsLive,
+                  as: :custom_lv
 
     # Gettext routes
     sign_in_route path: "/anmeldung",


### PR DESCRIPTION
(based on #564)

Components were missing a default `gettext_fn`, complaining without.

Test included.