### PR TITLE
feat: Display order for strategies in sign in page

### DIFF
--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -99,6 +99,8 @@ Renders sign in mark-up for an authenticated resource.
 
   * `:strategy_class` - CSS class for a `div` surrounding each strategy component.
 
+  * `:strategy_display_order` - Whether to display the form or link strategies first. Accepted values are `:forms_first` or `:links_first`.
+
 
 ## Password Sign-in
 ### `AshAuthentication.Phoenix.Components.Password`

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -108,9 +108,11 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       <% end %>
 
       <%= for {strategies, i} <- Enum.with_index(@strategies_by_resource) do %>
+        <% [top_strategies, bottom_strategies] = ordered_strategies(@overrides, strategies) %>
+
         <.strategies
           live_action={@live_action}
-          strategies={top_strategies(@overrides, strategies)}
+          strategies={top_strategies}
           path={@path}
           auth_routes_prefix={@auth_routes_prefix}
           reset_path={@reset_path}
@@ -131,7 +133,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
         <.strategies
           live_action={@live_action}
-          strategies={bottom_strategies(@overrides, strategies)}
+          strategies={bottom_strategies}
           auth_routes_prefix={@auth_routes_prefix}
           path={@path}
           reset_path={@reset_path}
@@ -171,23 +173,13 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
   defp sort_strategies_by_name(strategies), do: Enum.sort_by(strategies, & &1.name)
 
-  defp top_strategies(overrides, strategy_group) do
+  defp ordered_strategies(overrides, strategy_group) do
     case override_for(overrides, :strategy_display_order, :forms_first) do
       :links_first ->
-        strategy_group.link
+        [strategy_group.link, strategy_group.form]
 
       _ ->
-        strategy_group.form
-    end
-  end
-
-  defp bottom_strategies(overrides, strategy_group) do
-    case override_for(overrides, :strategy_display_order, :forms_first) do
-      :links_first ->
-        strategy_group.form
-
-      _ ->
-        strategy_group.link
+        [strategy_group.form, strategy_group.link]
     end
   end
 

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -6,7 +6,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
     authentication_error_container_class:
       "CSS class for the container for the text of the authentication error.",
     authentication_error_text_class: "CSS class for the authentication error text.",
-    strategy_display_order: "Whether to show first form strategies or link strategies."
+    strategy_display_order: "Whether to display the form or link strategies first. Accepted values are `:forms_first` or `:links_first`."
 
   @moduledoc """
   Renders sign in mark-up for an authenticated resource.

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -3,6 +3,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
     root_class: "CSS class for the root `div` element.",
     strategy_class: "CSS class for a `div` surrounding each strategy component.",
     show_banner: "Whether or not to show the banner.",
+    strategy_display_order: "Whether to show first form strategies or link strategies.",
     authentication_error_container_class:
       "CSS class for the container for the text of the authentication error.",
     authentication_error_text_class: "CSS class for the authentication error text."
@@ -107,23 +108,18 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       <% end %>
 
       <%= for {strategies, i} <- Enum.with_index(@strategies_by_resource) do %>
-        <%= if Enum.any?(strategies.form) do %>
-          <%= for strategy <- strategies.form do %>
-            <.strategy
-              component={component_for_strategy(strategy)}
-              live_action={@live_action}
-              strategy={strategy}
-              path={@path}
-              auth_routes_prefix={@auth_routes_prefix}
-              reset_path={@reset_path}
-              register_path={@register_path}
-              overrides={@overrides}
-              current_tenant={@current_tenant}
-              context={@context}
-              gettext_fn={@gettext_fn}
-            />
-          <% end %>
-        <% end %>
+        <.strategies
+          live_action={@live_action}
+          strategies={strategies.form}
+          path={@path}
+          auth_routes_prefix={@auth_routes_prefix}
+          reset_path={@reset_path}
+          register_path={@register_path}
+          overrides={@overrides}
+          current_tenant={@current_tenant}
+          context={@context}
+          gettext_fn={@gettext_fn}
+        />
 
         <%= if Enum.any?(strategies.form) && Enum.any?(strategies.link) do %>
           <.live_component
@@ -133,46 +129,43 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
           />
         <% end %>
 
-        <%= if Enum.any?(strategies.link) do %>
-          <%= for strategy <- strategies.link do %>
-            <.strategy
-              component={component_for_strategy(strategy)}
-              live_action={@live_action}
-              strategy={strategy}
-              auth_routes_prefix={@auth_routes_prefix}
-              path={@path}
-              reset_path={@reset_path}
-              register_path={@register_path}
-              overrides={@overrides}
-              current_tenant={@current_tenant}
-              context={@context}
-              gettext_fn={@gettext_fn}
-            />
-          <% end %>
-        <% end %>
+        <.strategies
+          live_action={@live_action}
+          strategies={strategies.link}
+          auth_routes_prefix={@auth_routes_prefix}
+          path={@path}
+          reset_path={@reset_path}
+          register_path={@register_path}
+          overrides={@overrides}
+          current_tenant={@current_tenant}
+          context={@context}
+          gettext_fn={@gettext_fn}
+        />
       <% end %>
     </div>
     """
   end
 
-  defp strategy(assigns) do
+  defp strategies(assigns) do
     ~H"""
-    <div class={override_for(@overrides, :strategy_class)}>
-      <.live_component
-        module={@component}
-        id={strategy_id(@strategy)}
-        strategy={@strategy}
-        auth_routes_prefix={@auth_routes_prefix}
-        path={@path}
-        reset_path={@reset_path}
-        register_path={@register_path}
-        live_action={@live_action}
-        overrides={@overrides}
-        current_tenant={@current_tenant}
-        context={@context}
-        gettext_fn={@gettext_fn}
-      />
-    </div>
+    <%= if Enum.any?(@strategies) do %>
+      <div :for={strategy <- @strategies} class={override_for(@overrides, :strategy_class)}>
+        <.live_component
+          module={component_for_strategy(strategy)}
+          id={strategy_id(strategy)}
+          strategy={strategy}
+          auth_routes_prefix={@auth_routes_prefix}
+          path={@path}
+          reset_path={@reset_path}
+          register_path={@register_path}
+          live_action={@live_action}
+          overrides={@overrides}
+          current_tenant={@current_tenant}
+          context={@context}
+          gettext_fn={@gettext_fn}
+        />
+      </div>
+    <% end %>
     """
   end
 

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -3,10 +3,10 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
     root_class: "CSS class for the root `div` element.",
     strategy_class: "CSS class for a `div` surrounding each strategy component.",
     show_banner: "Whether or not to show the banner.",
-    strategy_display_order: "Whether to show first form strategies or link strategies.",
     authentication_error_container_class:
       "CSS class for the container for the text of the authentication error.",
-    authentication_error_text_class: "CSS class for the authentication error text."
+    authentication_error_text_class: "CSS class for the authentication error text.",
+    strategy_display_order: "Whether to show first form strategies or link strategies."
 
   @moduledoc """
   Renders sign in mark-up for an authenticated resource.

--- a/lib/ash_authentication_phoenix/components/sign_in.ex
+++ b/lib/ash_authentication_phoenix/components/sign_in.ex
@@ -110,7 +110,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
       <%= for {strategies, i} <- Enum.with_index(@strategies_by_resource) do %>
         <.strategies
           live_action={@live_action}
-          strategies={strategies.form}
+          strategies={top_strategies(@overrides, strategies)}
           path={@path}
           auth_routes_prefix={@auth_routes_prefix}
           reset_path={@reset_path}
@@ -131,7 +131,7 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
 
         <.strategies
           live_action={@live_action}
-          strategies={strategies.link}
+          strategies={bottom_strategies(@overrides, strategies)}
           auth_routes_prefix={@auth_routes_prefix}
           path={@path}
           reset_path={@reset_path}
@@ -170,6 +170,26 @@ defmodule AshAuthentication.Phoenix.Components.SignIn do
   end
 
   defp sort_strategies_by_name(strategies), do: Enum.sort_by(strategies, & &1.name)
+
+  defp top_strategies(overrides, strategy_group) do
+    case override_for(overrides, :strategy_display_order, :forms_first) do
+      :links_first ->
+        strategy_group.link
+
+      _ ->
+        strategy_group.form
+    end
+  end
+
+  defp bottom_strategies(overrides, strategy_group) do
+    case override_for(overrides, :strategy_display_order, :forms_first) do
+      :links_first ->
+        strategy_group.form
+
+      _ ->
+        strategy_group.link
+    end
+  end
 
   defp strategy_id(strategy) do
     subject_name =

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -10,6 +10,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
 
   override SignInLive do
     set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+    set :strategy_display_order, :forms_first
   end
 
   override ResetLive do

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -10,7 +10,6 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
 
   override SignInLive do
     set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
-    set :strategy_display_order, :forms_first
   end
 
   override ResetLive do
@@ -45,6 +44,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
 
     set :authentication_error_container_class, "text-black dark:text-white text-center"
     set :authentication_error_text_class, ""
+    set :strategy_display_order, :forms_first
   end
 
   override Components.Banner do


### PR DESCRIPTION
Addresses #590 by adding override options for the order that the strategies can be displayed

<img width="775" alt="Screenshot 2025-03-10 at 16 52 57" src="https://github.com/user-attachments/assets/35c97c42-ba3c-4b87-9aad-52ecf795a306" />
