### PR TITLE
feat: Add override option for register form

### DIFF
--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -125,6 +125,8 @@ Generates sign in, registration and reset forms for a resource.
 
   * `:toggler_class` - CSS class for the toggler `a` element.
 
+  * `:register_form_module` - A Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.
+
 
 ### `AshAuthentication.Phoenix.Components.Password.RegisterForm`
 

--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -125,7 +125,7 @@ Generates sign in, registration and reset forms for a resource.
 
   * `:toggler_class` - CSS class for the toggler `a` element.
 
-  * `:register_form_module` - A Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.
+  * `:register_form_module` - A Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`. If you want to use this override it's advised to first copy the whole component from https://github.com/team-alembic/ash_authentication_phoenix/blob/main/lib/ash_authentication_phoenix/components/password/register_form.ex and then modify it according to your needs.
 
 
 ### `AshAuthentication.Phoenix.Components.Password.RegisterForm`

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -215,7 +215,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
         >
           <.live_component
             :let={form}
-            module={Password.RegisterForm}
+            module={override_for(@overrides, :register_form_module) || Password.RegisterForm}
             auth_routes_prefix={@auth_routes_prefix}
             id={@register_id}
             strategy={@strategy}
@@ -261,7 +261,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
         <div id={"#{@reset_id}-wrapper"} class={if @show == :reset, do: nil, else: @hide_class}>
           <.live_component
             :let={form}
-            module={override_for(@overrides, :reset_form_module) || Password.ResetForm}
+            module={Password.ResetForm}
             auth_routes_prefix={@auth_routes_prefix}
             id={@reset_id}
             strategy={@strategy}

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -12,7 +12,8 @@ defmodule AshAuthentication.Phoenix.Components.Password do
     reset_toggle_text:
       "Toggle text to display when the reset form is not showing (or `nil` to disable).",
     toggler_class: "CSS class for the toggler `a` element.",
-    register_form_module: "The Phoenix component to be used for the register form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.",
+    register_form_module:
+      "The Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.",
     slot_class: "CSS class for the `div` surrounding the slot."
 
   @moduledoc """

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -12,6 +12,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
     reset_toggle_text:
       "Toggle text to display when the reset form is not showing (or `nil` to disable).",
     toggler_class: "CSS class for the toggler `a` element.",
+    register_form_module: "The Phoenix component to be used for the register form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.",
     slot_class: "CSS class for the `div` surrounding the slot."
 
   @moduledoc """
@@ -260,7 +261,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
         <div id={"#{@reset_id}-wrapper"} class={if @show == :reset, do: nil, else: @hide_class}>
           <.live_component
             :let={form}
-            module={Password.ResetForm}
+            module={override_for(@overrides, :reset_form_module) || Password.ResetForm}
             auth_routes_prefix={@auth_routes_prefix}
             id={@reset_id}
             strategy={@strategy}

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -91,6 +91,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     set :reset_toggle_text, "Forgot your password?"
     set :show_first, :sign_in
     set :hide_class, "hidden"
+    set :register_form_module, AshAuthentication.Phoenix.Components.Password.RegisterForm
   end
 
   override Components.Password.SignInForm do


### PR DESCRIPTION
A way to override the whole registration for as to allow any customization of it.

In the screenshot below we are adding a "name" field on the top

<img width="672" alt="Screenshot 2025-04-18 at 11 28 02" src="https://github.com/user-attachments/assets/d80be1a3-0db0-4ea9-9ad6-7679e79ae590" />
