### PR TITLE
fix(Password.SignInForm): Slugify the form param to match what AA expects

### DIFF
--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -91,7 +91,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
       strategy.resource
       |> Form.for_action(strategy.sign_in_action_name,
         domain: domain,
-        as: subject_name |> to_string(),
+        as: subject_name |> to_string() |> slugify(),
         id:
           "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.sign_in_action_name}"
           |> slugify(),


### PR DESCRIPTION
There's not really a good reason that AA slugifies the subject name when looking for params, but it does, so in order to not break backwards compatibility we modify the form to match.

Thanks to @adamtharani for being the first person to notice this!