### PR TITLE
feat: google strategy uses official button svg

### DIFF
--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -53,8 +53,13 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
         href={auth_path(@socket, @subject_name, @auth_routes_prefix, @strategy, :request)}
         class={override_for(@overrides, :link_class)}
       >
-        <.icon icon={@strategy.icon} overrides={@overrides} />
-        {_gettext("Sign in with #{strategy_name(@strategy)}")}
+        <%= case @strategy.icon do %>
+          <% :google -> %>
+            <.icon icon={@strategy.icon} overrides={@overrides} />
+          <% _ -> %>
+            <.icon icon={@strategy.icon} overrides={@overrides} />
+            {_gettext("Sign in with #{strategy_name(@strategy)}")}
+        <% end %>
       </a>
     </div>
     """


### PR DESCRIPTION
...instead of a plain button with "Sign in with Google" text.

This is similar to other icon cases in the same file that already support the vendor-specific icon (e.g. GitHub).