### PR TITLE
fix: Remove border from google svg

### DIFF
--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -133,7 +133,6 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
     <rect x="0.5" y="0.5" width="174" height="39" rx="3.5" stroke="#747775"/>
     <defs>
     <clipPath id="clip0_710_6235">
-    <rect width="20" height="20" fill="white" transform="translate(12 10)"/>
     </clipPath>
     </defs>
     </svg>


### PR DESCRIPTION
Removes the fixed border from the SVG. 

<img width="568" alt="Screenshot 2025-06-14 at 20 48 21" src="https://github.com/user-attachments/assets/c7799def-b8de-4a82-85f9-374b95c6f779" />

This allows to use the override class to determine the how any border styling will be aplied.

```
  override Components.OAuth2 do
    set :root_class, "w-full mt-2 mb-4"

    set :link_class, """
    w-full flex justify-center items-center py-2 px-1
    """

    set :icon_class, "w-full border-2 border-black rounded-md"
  end
  ```

Fixes: https://github.com/team-alembic/ash_authentication_phoenix/issues/632

https://discord.com/channels/711271361523351632/1253437793053577226/1383517555997802618
