### PR TITLE
Example how to match an attribute like a user role in a on_mount hook.

### DIFF
--- a/documentation/tutorials/liveview.md
+++ b/documentation/tutorials/liveview.md
@@ -73,6 +73,36 @@ And we can use this as follows:
   end
   # ...
 ```
+Or, if we want to match a specific user attribute like :role we can use the `on_mount` hook to check it:
+```elixir
+def on_mount([required_role: role], _params, _session, socket) do
+  if socket.assigns[:current_user] && socket.assigns[:current_user].role == role do
+    {:cont, socket}
+  else
+    {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+  end
+end
+```
+Or muliple roles:
+```elixir
+def on_mount([required_roles: roles], _params, _session, socket) do
+  if socket.assigns[:current_user] && Enum.any?(roles, &(socket.assigns[:current_user].role == &1)) do
+    {:cont, socket}
+  else
+    {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+  end
+end
+```
+And use it in a on_mount call in a LiveView:
+```elixir
+on_mount {MyAppWeb.LiveUserAuth, [required_role: :admin]}
+```
+Or
+```elixir
+on_mount {MyAppWeb.LiveUserAuth, [required_roles: [:admin, :staff]]}
+```
+
+
 
 You can also use this to prevent users from visiting the auto generated `sign_in` route:
 

--- a/documentation/tutorials/liveview.md
+++ b/documentation/tutorials/liveview.md
@@ -73,7 +73,7 @@ And we can use this as follows:
   end
   # ...
 ```
-Or, if we want to match a specific user attribute like :role we can use the `on_mount` hook to check it:
+If you want to match a specific user attribute like :role for allowing access you can use the `on_mount` hook to check it:
 ```elixir
 def on_mount([required_role: role], _params, _session, socket) do
   if socket.assigns[:current_user] && socket.assigns[:current_user].role == role do
@@ -83,7 +83,7 @@ def on_mount([required_role: role], _params, _session, socket) do
   end
 end
 ```
-Or muliple roles:
+You can also match multiple roles:
 ```elixir
 def on_mount([required_roles: roles], _params, _session, socket) do
   if socket.assigns[:current_user] && Enum.any?(roles, &(socket.assigns[:current_user].role == &1)) do
@@ -93,11 +93,11 @@ def on_mount([required_roles: roles], _params, _session, socket) do
   end
 end
 ```
-And use it in a on_mount call in a LiveView:
+Use it in a on_mount call in a LiveView:
 ```elixir
 on_mount {MyAppWeb.LiveUserAuth, [required_role: :admin]}
 ```
-Or
+
 ```elixir
 on_mount {MyAppWeb.LiveUserAuth, [required_roles: [:admin, :staff]]}
 ```


### PR DESCRIPTION
This pull request updates the `documentation/tutorials/liveview.md` file to include examples of using the `on_mount` hook for role-based access control in LiveView. The changes demonstrate how to restrict access based on a user's role or multiple roles. 

Enhancements to LiveView documentation:

* Added examples of using the `on_mount` hook to check for a specific user role (`required_role`) or multiple roles (`required_roles`) for access control. These examples include both the implementation of the `on_mount` function and its usage in LiveViews.