### PR TITLE
Add override options to reset and sign in forms

### DIFF
--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -113,6 +113,10 @@ Generates sign in, registration and reset forms for a resource.
 
   * `:register_form_module` - The Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.
 
+  * `:sign_in_form_module` - The Phoenix component to be used for the sign in form. Defaults to `AshAuthentication.Phoenix.Components.Password.SignInForm`.
+
+  * `:reset_form_module` - The Phoenix component to be used for the reset form. Defaults to `AshAuthentication.Phoenix.Components.Password.ResetForm`.
+
   * `:register_toggle_text` - Toggle text to display when the register form is not showing (or `nil` to disable).
 
   * `:reset_toggle_text` - Toggle text to display when the reset form is not showing (or `nil` to disable).

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -14,6 +14,10 @@ defmodule AshAuthentication.Phoenix.Components.Password do
     toggler_class: "CSS class for the toggler `a` element.",
     register_form_module:
       "The Phoenix component to be used for the registration form. Defaults to `AshAuthentication.Phoenix.Components.Password.RegisterForm`.",
+    sign_in_form_module:
+      "The Phoenix component to be used for the sign in form. Defaults to `AshAuthentication.Phoenix.Components.Password.SignInForm`.",
+    reset_form_module:
+      "The Phoenix component to be used for the reset form. Defaults to `AshAuthentication.Phoenix.Components.Password.ResetForm`.",
     slot_class: "CSS class for the `div` surrounding the slot."
 
   @moduledoc """
@@ -167,7 +171,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
       <div id={"#{@sign_in_id}-wrapper"} class={if @show == :sign_in, do: nil, else: @hide_class}>
         <.live_component
           :let={form}
-          module={Password.SignInForm}
+          module={override_for(@overrides, :sign_in_form_module) || Password.SignInForm}
           auth_routes_prefix={@auth_routes_prefix}
           id={@sign_in_id}
           strategy={@strategy}
@@ -262,7 +266,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
         <div id={"#{@reset_id}-wrapper"} class={if @show == :reset, do: nil, else: @hide_class}>
           <.live_component
             :let={form}
-            module={Password.ResetForm}
+            module={override_for(@overrides, :reset_form_module) || Password.ResetForm}
             auth_routes_prefix={@auth_routes_prefix}
             id={@reset_id}
             strategy={@strategy}

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -134,6 +134,8 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     set :show_first, :sign_in
     set :hide_class, "hidden"
     set :register_form_module, AshAuthentication.Phoenix.Components.Password.RegisterForm
+    set :sign_in_form_module, AshAuthentication.Phoenix.Components.Password.SignInForm
+    set :reset_form_module, AshAuthentication.Phoenix.Components.Password.ResetForm
   end
 
   override Components.Password.SignInForm do


### PR DESCRIPTION
[Discord #ash_authentication channel](https://discord.com/channels/711271361523351632/1253437793053577226/1387036675904897074)

This is the same thing with https://github.com/team-alembic/ash_authentication_phoenix/pull/602 ("A way to override the whole registration for as to allow any customization of it."), but adding options to both reset and sign in for full customization.