### PR TITLE
improvement: add optional daisyUI overrides

### DIFF
--- a/documentation/tutorials/get-started.md
+++ b/documentation/tutorials/get-started.md
@@ -194,7 +194,9 @@ If you would like to use your own layout file instead, you can specify this as a
 reset_route(layout: {MyAppWeb, :live}, auth_routes_prefix: "/auth")
 ```
 
-## Tailwind
+## Styling
+
+### Tailwind
 
 If you plan on using our default [Tailwind](https://tailwindcss.com/)-based
 components without overriding them you will need to modify your
@@ -252,6 +254,26 @@ module.exports = {
   ],
 };
 ```
+
+### daisyUI
+
+If you're using [daisyUI](https://daisyui.com/), you can use the daisyUI-specific overrides instead of the default Tailwind ones. Replace `AshAuthentication.Phoenix.Overrides.Default` with `AshAuthentication.Phoenix.Overrides.DaisyUI` in your router:
+
+```elixir
+sign_in_route register_path: "/register",
+              reset_path: "/reset",
+              auth_routes_prefix: "/auth",
+              on_mount: [{ExampleWeb.LiveUserAuth, :live_no_user}],
+              overrides: [AshAuthentication.Phoenix.Overrides.DaisyUI]
+```
+
+To enable dark theme support for header images, add this to your `app.css`:
+
+```css
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+```
+
+This allows the `dark:hidden` and `dark:block` classes to work with daisyUI's theme system instead of just system dark mode.
 
 ## Example home.html.heex
 

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -85,14 +85,11 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   end
 
   override Components.HorizontalRule do
-    set :root_class, "relative my-2"
-    set :hr_outer_class, "absolute inset-0 flex items-center"
-    set :hr_inner_class, "w-full border-t border-base-300"
-    set :text_outer_class, "relative flex justify-center text-sm"
-
-    set :text_inner_class,
-        "px-2 bg-base-100 text-base-content/60 font-medium"
-
+    set :root_class, "divider my-2"
+    set :hr_outer_class, "hidden"
+    set :hr_inner_class, "hidden"
+    set :text_outer_class, "contents"
+    set :text_inner_class, "contents"
     set :text, "or"
   end
 
@@ -118,7 +115,10 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.Password do
     set :root_class, "mt-4 mb-4"
     set :interstitial_class, "flex flex-row justify-between content-between text-sm font-medium"
-    set :toggler_class, "flex-none text-primary hover:text-primary-focus px-2 first:pl-0 last:pr-0"
+
+    set :toggler_class,
+        "flex-none text-primary hover:text-primary-focus px-2 first:pl-0 last:pr-0"
+
     set :sign_in_toggle_text, "Already have an account?"
     set :register_toggle_text, "Need an account?"
     set :reset_toggle_text, "Forgot your password?"

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -16,11 +16,11 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   }
 
   override SignInLive do
-    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+    set :root_class, "grid h-screen place-items-center bg-base-100"
   end
 
   override ConfirmLive do
-    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+    set :root_class, "grid h-screen place-items-center bg-base-100"
   end
 
   override Components.Confirm do
@@ -35,14 +35,14 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.Confirm.Input do
     set :submit_class, """
     w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
     mt-4 mb-4
     """
   end
 
   override ResetLive do
-    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+    set :root_class, "grid h-screen place-items-center bg-base-100"
   end
 
   override Components.Reset do
@@ -56,7 +56,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
   override Components.Reset.Form do
     set :root_class, nil
-    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-base-content"
     set :form_class, nil
     set :spacer_class, "py-1"
     set :button_text, "Change password"
@@ -71,7 +71,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
     set :strategy_class, "mx-auto w-full max-w-sm lg:w-96"
 
-    set :authentication_error_container_class, "text-black dark:text-white text-center"
+    set :authentication_error_container_class, "text-base-content text-center"
     set :authentication_error_text_class, ""
     set :strategy_display_order, :forms_first
   end
@@ -91,22 +91,22 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.HorizontalRule do
     set :root_class, "relative my-2"
     set :hr_outer_class, "absolute inset-0 flex items-center"
-    set :hr_inner_class, "w-full border-t border-gray-300 dark:border-gray-700"
+    set :hr_inner_class, "w-full border-t border-base-300"
     set :text_outer_class, "relative flex justify-center text-sm"
 
     set :text_inner_class,
-        "px-2 bg-white text-gray-400 font-medium dark:bg-gray-900 dark:text-gray-500"
+        "px-2 bg-base-100 text-base-content/60 font-medium"
 
     set :text, "or"
   end
 
   override MagicSignInLive do
-    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+    set :root_class, "grid h-screen place-items-center bg-base-100"
   end
 
   override Components.MagicLink do
     set :root_class, "mt-4 mb-4"
-    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-base-content"
     set :form_class, nil
 
     set :request_flash_text,
@@ -118,8 +118,8 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.MagicLink.Input do
     set :submit_class, """
     w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
     mt-4 mb-4
     """
   end
@@ -127,7 +127,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.Password do
     set :root_class, "mt-4 mb-4"
     set :interstitial_class, "flex flex-row justify-between content-between text-sm font-medium"
-    set :toggler_class, "flex-none text-blue-500 hover:text-blue-600 px-2 first:pl-0 last:pr-0"
+    set :toggler_class, "flex-none text-primary hover:text-primary-focus px-2 first:pl-0 last:pr-0"
     set :sign_in_toggle_text, "Already have an account?"
     set :register_toggle_text, "Need an account?"
     set :reset_toggle_text, "Forgot your password?"
@@ -138,7 +138,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
   override Components.Password.SignInForm do
     set :root_class, nil
-    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-base-content"
     set :form_class, nil
     set :slot_class, "my-4"
     set :button_text, "Sign in"
@@ -147,7 +147,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
   override Components.Password.RegisterForm do
     set :root_class, nil
-    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-base-content"
     set :form_class, nil
     set :slot_class, "my-4"
     set :button_text, "Register"
@@ -156,7 +156,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
   override Components.Password.ResetForm do
     set :root_class, nil
-    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-base-content"
     set :form_class, nil
     set :slot_class, "my-4"
     set :button_text, "Request reset password link"
@@ -167,31 +167,31 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   end
 
   override Components.Password.Input do
-    set :field_class, "mt-2 mb-2 dark:text-white"
-    set :label_class, "block text-sm font-medium text-gray-700 mb-1 dark:text-white"
+    set :field_class, "mt-2 mb-2"
+    set :label_class, "block text-sm font-medium text-base-content mb-1"
 
     @base_input_class """
     appearance-none block w-full px-3 py-2 border rounded-md
-    shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm
-    dark:text-black
+    shadow-sm placeholder-base-content/60 focus:outline-none sm:text-sm
+    text-base-content bg-base-100
     """
 
     set :input_class,
         @base_input_class <>
           """
-          border-gray-300 focus:ring-blue-400 focus:border-blue-500
+          border-base-300 focus:ring-primary focus:border-primary
           """
 
     set :input_class_with_error,
         @base_input_class <>
           """
-          border-red-400 focus:border-red-400 focus:ring-red-300
+          border-error focus:border-error focus:ring-error
           """
 
     set :submit_class, """
     w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
     mt-4 mb-4
     """
 
@@ -199,7 +199,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :password_confirmation_input_label, "Password Confirmation"
     set :identity_input_label, "Email"
     set :identity_input_placeholder, nil
-    set :error_ul, "text-red-400 font-light my-3 italic text-sm"
+    set :error_ul, "text-error font-light my-3 italic text-sm"
     set :error_li, nil
     set :input_debounce, 350
   end
@@ -209,8 +209,8 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
     set :link_class, """
     w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-black bg-gray-200 hover:bg-gray-300
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    shadow-sm text-sm font-medium text-base-content bg-base-200 hover:bg-base-300
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
     inline-flex items-center
     """
 
@@ -222,9 +222,8 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
 
     set :link_class, """
     w-full flex justify-center px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-white bg-black focus:outline-none
-    focus:ring-2 focus:ring-offset-2 focus:ring-black inline-flex items-center
-    dark:bg-white dark:text-black dark:ring-white
+    shadow-sm text-sm font-medium text-neutral-content bg-neutral focus:outline-none
+    focus:ring-2 focus:ring-offset-2 focus:ring-neutral inline-flex items-center
     """
 
     set :icon_class, ""

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -1,8 +1,9 @@
 defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   @moduledoc """
-  This is the default overrides for our component UI.
+  This is the daisyUI overrides for our component UI.
+  Copied from the AshAuthentication.Phoenix.Overrides.Default module with color classes adjusted.
 
-  The CSS styles are based on [TailwindCSS](https://tailwindcss.com/).
+  The CSS styles are based on [daisyUI](https://daisyui.com/).
   """
 
   use AshAuthentication.Phoenix.Overrides

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -1,7 +1,7 @@
 defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   @moduledoc """
   This is the daisyUI overrides for our component UI.
-  Copied from the AshAuthentication.Phoenix.Overrides.Default module with color classes adjusted.
+  Copied from the AshAuthentication.Phoenix.Overrides.Default module with tweaks.
 
   The CSS styles are based on [daisyUI](https://daisyui.com/).
   """

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -161,23 +161,11 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :field_class, "mt-2 mb-2"
     set :label_class, "block text-sm font-medium text-base-content mb-1"
 
-    @base_input_class """
-    appearance-none block w-full px-3 py-2 border rounded-md
-    shadow-sm placeholder-base-content/60 focus:outline-none sm:text-sm
-    text-base-content bg-base-100
-    """
+    @base_input_class "input w-full"
 
-    set :input_class,
-        @base_input_class <>
-          """
-          border-base-300 focus:ring-primary focus:border-primary
-          """
+    set :input_class, @base_input_class
 
-    set :input_class_with_error,
-        @base_input_class <>
-          """
-          border-error focus:border-error focus:ring-error
-          """
+    set :input_class_with_error, @base_input_class <> " input-error"
 
     set :submit_class, "btn btn-primary btn-block mt-4 mb-4"
 

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -1,0 +1,232 @@
+defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
+  @moduledoc """
+  This is the default overrides for our component UI.
+
+  The CSS styles are based on [TailwindCSS](https://tailwindcss.com/).
+  """
+
+  use AshAuthentication.Phoenix.Overrides
+
+  alias AshAuthentication.Phoenix.{
+    Components,
+    ConfirmLive,
+    MagicSignInLive,
+    ResetLive,
+    SignInLive
+  }
+
+  override SignInLive do
+    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+  end
+
+  override ConfirmLive do
+    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+  end
+
+  override Components.Confirm do
+    set :root_class, """
+    flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none
+    lg:px-20 xl:px-24
+    """
+
+    set :strategy_class, "mx-auto w-full max-w-sm lg:w-96"
+  end
+
+  override Components.Confirm.Input do
+    set :submit_class, """
+    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
+    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    mt-4 mb-4
+    """
+  end
+
+  override ResetLive do
+    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+  end
+
+  override Components.Reset do
+    set :root_class, """
+    flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none
+    lg:px-20 xl:px-24
+    """
+
+    set :strategy_class, "mx-auto w-full max-w-sm lg:w-96"
+  end
+
+  override Components.Reset.Form do
+    set :root_class, nil
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :form_class, nil
+    set :spacer_class, "py-1"
+    set :button_text, "Change password"
+    set :disable_button_text, "Changing password ..."
+  end
+
+  override Components.SignIn do
+    set :root_class, """
+    flex-1 flex flex-col justify-center py-12 px-4 sm:px-6 lg:flex-none
+    lg:px-20 xl:px-24
+    """
+
+    set :strategy_class, "mx-auto w-full max-w-sm lg:w-96"
+
+    set :authentication_error_container_class, "text-black dark:text-white text-center"
+    set :authentication_error_text_class, ""
+    set :strategy_display_order, :forms_first
+  end
+
+  override Components.Banner do
+    set :root_class, "w-full flex justify-center py-2"
+    set :href_class, nil
+    set :href_url, "/"
+    set :image_class, "block dark:hidden"
+    set :dark_image_class, "hidden dark:block"
+    set :image_url, "https://ash-hq.org/images/ash-framework-light.png"
+    set :dark_image_url, "https://ash-hq.org/images/ash-framework-dark.png"
+    set :text_class, nil
+    set :text, nil
+  end
+
+  override Components.HorizontalRule do
+    set :root_class, "relative my-2"
+    set :hr_outer_class, "absolute inset-0 flex items-center"
+    set :hr_inner_class, "w-full border-t border-gray-300 dark:border-gray-700"
+    set :text_outer_class, "relative flex justify-center text-sm"
+
+    set :text_inner_class,
+        "px-2 bg-white text-gray-400 font-medium dark:bg-gray-900 dark:text-gray-500"
+
+    set :text, "or"
+  end
+
+  override MagicSignInLive do
+    set :root_class, "grid h-screen place-items-center dark:bg-gray-900"
+  end
+
+  override Components.MagicLink do
+    set :root_class, "mt-4 mb-4"
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :form_class, nil
+
+    set :request_flash_text,
+        "If this user exists in our database, you will be contacted with a sign-in link shortly."
+
+    set :disable_button_text, "Requesting ..."
+  end
+
+  override Components.MagicLink.Input do
+    set :submit_class, """
+    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
+    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    mt-4 mb-4
+    """
+  end
+
+  override Components.Password do
+    set :root_class, "mt-4 mb-4"
+    set :interstitial_class, "flex flex-row justify-between content-between text-sm font-medium"
+    set :toggler_class, "flex-none text-blue-500 hover:text-blue-600 px-2 first:pl-0 last:pr-0"
+    set :sign_in_toggle_text, "Already have an account?"
+    set :register_toggle_text, "Need an account?"
+    set :reset_toggle_text, "Forgot your password?"
+    set :show_first, :sign_in
+    set :hide_class, "hidden"
+    set :register_form_module, AshAuthentication.Phoenix.Components.Password.RegisterForm
+  end
+
+  override Components.Password.SignInForm do
+    set :root_class, nil
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :form_class, nil
+    set :slot_class, "my-4"
+    set :button_text, "Sign in"
+    set :disable_button_text, "Signing in ..."
+  end
+
+  override Components.Password.RegisterForm do
+    set :root_class, nil
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :form_class, nil
+    set :slot_class, "my-4"
+    set :button_text, "Register"
+    set :disable_button_text, "Registering ..."
+  end
+
+  override Components.Password.ResetForm do
+    set :root_class, nil
+    set :label_class, "mt-2 mb-4 text-2xl tracking-tight font-bold text-gray-900 dark:text-white"
+    set :form_class, nil
+    set :slot_class, "my-4"
+    set :button_text, "Request reset password link"
+    set :disable_button_text, "Requesting ..."
+
+    set :reset_flash_text,
+        "If this user exists in our system, you will be contacted with password reset instructions shortly."
+  end
+
+  override Components.Password.Input do
+    set :field_class, "mt-2 mb-2 dark:text-white"
+    set :label_class, "block text-sm font-medium text-gray-700 mb-1 dark:text-white"
+
+    @base_input_class """
+    appearance-none block w-full px-3 py-2 border rounded-md
+    shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm
+    dark:text-black
+    """
+
+    set :input_class,
+        @base_input_class <>
+          """
+          border-gray-300 focus:ring-blue-400 focus:border-blue-500
+          """
+
+    set :input_class_with_error,
+        @base_input_class <>
+          """
+          border-red-400 focus:border-red-400 focus:ring-red-300
+          """
+
+    set :submit_class, """
+    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
+    shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    mt-4 mb-4
+    """
+
+    set :password_input_label, "Password"
+    set :password_confirmation_input_label, "Password Confirmation"
+    set :identity_input_label, "Email"
+    set :identity_input_placeholder, nil
+    set :error_ul, "text-red-400 font-light my-3 italic text-sm"
+    set :error_li, nil
+    set :input_debounce, 350
+  end
+
+  override Components.OAuth2 do
+    set :root_class, "w-full mt-2 mb-4"
+
+    set :link_class, """
+    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
+    shadow-sm text-sm font-medium text-black bg-gray-200 hover:bg-gray-300
+    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+    inline-flex items-center
+    """
+
+    set :icon_class, "-ml-0.4 mr-2 h-4 w-4"
+  end
+
+  override Components.Apple do
+    set :root_class, "w-full mt-2 mb-4"
+
+    set :link_class, """
+    w-full flex justify-center px-4 border border-transparent rounded-md
+    shadow-sm text-sm font-medium text-white bg-black focus:outline-none
+    focus:ring-2 focus:ring-offset-2 focus:ring-black inline-flex items-center
+    dark:bg-white dark:text-black dark:ring-white
+    """
+
+    set :icon_class, ""
+  end
+end

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -34,12 +34,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   end
 
   override Components.Confirm.Input do
-    set :submit_class, """
-    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
-    mt-4 mb-4
-    """
+    set :submit_class, "btn btn-primary btn-block mt-4 mb-4"
   end
 
   override ResetLive do
@@ -117,12 +112,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   end
 
   override Components.MagicLink.Input do
-    set :submit_class, """
-    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
-    mt-4 mb-4
-    """
+    set :submit_class, "btn btn-primary btn-block mt-4 mb-4"
   end
 
   override Components.Password do
@@ -189,12 +179,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
           border-error focus:border-error focus:ring-error
           """
 
-    set :submit_class, """
-    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-primary-content bg-primary hover:bg-primary-focus
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
-    mt-4 mb-4
-    """
+    set :submit_class, "btn btn-primary btn-block mt-4 mb-4"
 
     set :password_input_label, "Password"
     set :password_confirmation_input_label, "Password Confirmation"
@@ -208,12 +193,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.OAuth2 do
     set :root_class, "w-full mt-2 mb-4"
 
-    set :link_class, """
-    w-full flex justify-center py-2 px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-base-content bg-base-200 hover:bg-base-300
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
-    inline-flex items-center
-    """
+    set :link_class, "btn btn-outline btn-block"
 
     set :icon_class, "-ml-0.4 mr-2 h-4 w-4"
   end
@@ -221,11 +201,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
   override Components.Apple do
     set :root_class, "w-full mt-2 mb-4"
 
-    set :link_class, """
-    w-full flex justify-center px-4 border border-transparent rounded-md
-    shadow-sm text-sm font-medium text-neutral-content bg-neutral focus:outline-none
-    focus:ring-2 focus:ring-offset-2 focus:ring-neutral inline-flex items-center
-    """
+    set :link_class, "btn btn-neutral btn-block"
 
     set :icon_class, ""
   end


### PR DESCRIPTION
* adds `AshAuthentication.Phoenix.Overrides.DaisyUI`, based on a copy of `AshAuthentication.Phoenix.Overrides.Default`
* adds some usage docs

Based on some overrides I'm using in production, but a bit more comprehensive.
Tested with password + magic link, but not any of the oauth setups.

Some screenshots:

![light_login](https://github.com/user-attachments/assets/293dfa27-7674-4457-bed0-809935571a0c)
![dark_register](https://github.com/user-attachments/assets/fc29e5c1-e704-43ad-be2e-0839da2ce766)
![dark_error](https://github.com/user-attachments/assets/bca223db-1850-4bc2-93df-d5e1df955b3f)
