### PR TITLE
fix: add missing override for magic link input submit_label

### DIFF
--- a/lib/ash_authentication_phoenix/components/magic_link/input.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link/input.ex
@@ -30,8 +30,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink.Input do
     * `strategy` - The configuration map as per
       `AshAuthentication.authenticated_resources/1`.  Required.
     * `form` - An `AshPhoenix.Form`.  Required.
-    * `submit_label` - The text to show in the submit label.  Generated from the
-      configured action name (via `Phoenix.Naming.humanize/1`) if not supplied.
+    * `submit_label` - The text to show in the submit label.
     * `overrides` - A list of override modules.
     * `gettext_fn` - Optional text translation function.
   """
@@ -47,7 +46,9 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink.Input do
       assigns
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:gettext_fn, fn -> nil end)
-      |> assign_new(:submit_label, fn -> fn _ -> "Sign in" end end)
+      |> assign_new(:submit_label, fn ->
+        fn _ -> override_for(assigns.overrides, :submit_label) end
+      end)
       |> assign_new(:disable_text, fn -> nil end)
       |> update(:submit_label, fn submit_label ->
         if is_function(submit_label) do

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -122,6 +122,8 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
     mt-4 mb-4
     """
+
+    set :submit_label, "Sign in"
   end
 
   override Components.Password do


### PR DESCRIPTION
This PR adds `submit_label` override for the magic link input/sign in which wasn't being used