### PR TITLE
improvement: install with daisyUI overrides if using daisyUI

### DIFF
--- a/dev/dev_web/router.ex
+++ b/dev/dev_web/router.ex
@@ -35,12 +35,12 @@ defmodule DevWeb.Router do
 
     magic_sign_in_route(Example.Accounts.User, :magic_link,
       auth_routes_prefix: "/auth",
-      overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+      overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
     )
 
     sign_in_route(
       path: "/sign-in",
-      overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default],
+      overrides: [DevWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI],
       auth_routes_prefix: "/auth"
     )
 

--- a/dev/dev_web/templates/layout/root.html.heex
+++ b/dev/dev_web/templates/layout/root.html.heex
@@ -8,8 +8,8 @@
     <.live_title>
       {assigns[:page_title] || "Dev"}
     </.live_title>
-    <script defer src="https://cdn.tailwindcss.com">
-    </script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <script type="module" crossorigin>
       import 'https://cdn.jsdelivr.net/gh/phoenixframework/phoenix_html@v3.2.0/priv/static/phoenix_html.js';
       import { Socket } from 'https://cdn.jsdelivr.net/gh/phoenixframework/phoenix@v1.6.14/priv/static/phoenix.mjs';

--- a/dev/dev_web/templates/layout/root.html.heex
+++ b/dev/dev_web/templates/layout/root.html.heex
@@ -9,7 +9,8 @@
       {assigns[:page_title] || "Dev"}
     </.live_title>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
-    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4">
+    </script>
     <script type="module" crossorigin>
       import 'https://cdn.jsdelivr.net/gh/phoenixframework/phoenix_html@v3.2.0/priv/static/phoenix_html.js';
       import { Socket } from 'https://cdn.jsdelivr.net/gh/phoenixframework/phoenix@v1.6.14/priv/static/phoenix.mjs';

--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -165,22 +165,22 @@ if Code.ensure_loaded?(Igniter) do
 
           # Remove these if you'd like to use your own authentication views
           sign_in_route register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth", on_mount: [{#{inspect(web_module)}.LiveUserAuth, :live_no_user}],
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
+            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
 
           # Remove this if you do not want to use the reset password feature
-          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
+          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
 
           # Remove this if you do not use the confirmation strategy
           confirm_route #{inspect(options[:user])},
             :confirm_new_user,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
+            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
 
           # Remove this if you do not use the magic link strategy.
           magic_sign_in_route #{inspect(options[:user])},
             :magic_link,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.Default]
+            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
           """,
           with_pipelines: [:browser],
           arg2: Igniter.Libs.Phoenix.web_module(igniter),

--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -146,6 +146,13 @@ if Code.ensure_loaded?(Igniter) do
       with {_, _source, zipper} <- Igniter.Project.Module.find_module!(igniter, router),
            {:ok, zipper} <- Igniter.Code.Common.move_to_do_block(zipper),
            :error <- Igniter.Code.Module.move_to_use(zipper, AshAuthentication.Phoenix.Router) do
+        override_module =
+          if Igniter.exists?(igniter, "assets/vendor/daisyui.js") do
+            AshAuthentication.Phoenix.Overrides.DaisyUI
+          else
+            AshAuthentication.Phoenix.Overrides.Default
+          end
+
         igniter
         |> use_authentication_phoenix_router(router)
         |> Igniter.Libs.Phoenix.append_to_pipeline(:browser, "plug :load_from_session",
@@ -165,22 +172,22 @@ if Code.ensure_loaded?(Igniter) do
 
           # Remove these if you'd like to use your own authentication views
           sign_in_route register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth", on_mount: [{#{inspect(web_module)}.LiveUserAuth, :live_no_user}],
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
+            overrides: [#{inspect(overrides)}, #{override_module}]
 
           # Remove this if you do not want to use the reset password feature
-          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
+          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, #{override_module}]
 
           # Remove this if you do not use the confirmation strategy
           confirm_route #{inspect(options[:user])},
             :confirm_new_user,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
+            overrides: [#{inspect(overrides)}, #{override_module}]
 
           # Remove this if you do not use the magic link strategy.
           magic_sign_in_route #{inspect(options[:user])},
             :magic_link,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, AshAuthentication.Phoenix.Overrides.DaisyUI]
+            overrides: [#{inspect(overrides)}, #{override_module}]
           """,
           with_pipelines: [:browser],
           arg2: Igniter.Libs.Phoenix.web_module(igniter),

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -241,25 +241,25 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     + |      reset_path: "/reset",
     + |      auth_routes_prefix: "/auth",
     + |      on_mount: [{TestWeb.LiveUserAuth, :live_no_user}],
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
     + |    )
     + |
     + |    # Remove this if you do not want to use the reset password feature
     + |    reset_route(
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
     + |    )
     + |
     + |    # Remove this if you do not use the confirmation strategy
     + |    confirm_route(Test.Accounts.User, :confirm_new_user,
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
     + |    )
     + |
     + |    # Remove this if you do not use the magic link strategy.
     + |    magic_sign_in_route(Test.Accounts.User, :magic_link,
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
     + |    )
     + |  end
     """)

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -1,13 +1,14 @@
 # credo:disable-for-this-file Credo.Check.Design.AliasUsage
 defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
-  use ExUnit.Case
+  use ExUnit.Case, parameterize: [%{daisy_ui: true}, %{daisy_ui: false}]
   @moduletag :igniter
 
   import Igniter.Test
 
-  setup do
+  setup context do
     igniter =
       test_project()
+      |> maybe_add_daisy_ui(context)
       |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
       |> Igniter.Project.Deps.add_dep({:ash_authentication, ">= 0.0.0"})
       |> Igniter.Project.Formatter.add_formatter_plugin(Spark.Formatter)
@@ -32,7 +33,14 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
       """)
       |> apply_igniter!()
 
-    [igniter: igniter]
+    base_override =
+      if context.daisy_ui do
+        AshAuthentication.Phoenix.Overrides.DaisyUI
+      else
+        AshAuthentication.Phoenix.Overrides.Default
+      end
+
+    [igniter: igniter, base_override: base_override]
   end
 
   test "installation is idempotent", %{igniter: igniter} do
@@ -196,7 +204,10 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     """)
   end
 
-  test "installation modifies the router", %{igniter: igniter} do
+  test "installation modifies the router", %{
+    igniter: igniter,
+    base_override: base_override
+  } do
     igniter
     |> Igniter.compose_task("ash_authentication_phoenix.install")
     |> assert_has_patch("lib/test_web/router.ex", """
@@ -241,27 +252,33 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     + |      reset_path: "/reset",
     + |      auth_routes_prefix: "/auth",
     + |      on_mount: [{TestWeb.LiveUserAuth, :live_no_user}],
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
     + |    )
     + |
     + |    # Remove this if you do not want to use the reset password feature
     + |    reset_route(
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
     + |    )
     + |
     + |    # Remove this if you do not use the confirmation strategy
     + |    confirm_route(Test.Accounts.User, :confirm_new_user,
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
     + |    )
     + |
     + |    # Remove this if you do not use the magic link strategy.
     + |    magic_sign_in_route(Test.Accounts.User, :magic_link,
     + |      auth_routes_prefix: "/auth",
-    + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.DaisyUI]
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
     + |    )
     + |  end
     """)
   end
+
+  defp maybe_add_daisy_ui(igniter, %{daisy_ui: true}) do
+    Igniter.create_new_file(igniter, "assets/vendor/daisyui.js", "")
+  end
+
+  defp maybe_add_daisy_ui(igniter, _), do: igniter
 end


### PR DESCRIPTION
* switches install to use daisyui overrides when using daisyui
* switches included test app to use daisyui overrides

~~Not sure if we wanted to do something like:~~
~~* check phoenix version, use daisyui overrides if 1.8+ otherwise default~~
~~* or just wait until phoenix 1.8 is released proper to merge~~
~~* add separate test app pages for default/daisyui overrides~~