### PR TITLE
feat: Add OAuth2 Icon Overrides

### DIFF
--- a/lib/ash_authentication_phoenix/components/oauth2.ex
+++ b/lib/ash_authentication_phoenix/components/oauth2.ex
@@ -2,7 +2,8 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
   use AshAuthentication.Phoenix.Overrides.Overridable,
     root_class: "CSS classes for the root `div` element.",
     link_class: "CSS classes for the `a` element.",
-    icon_class: "CSS classes for the icon SVG."
+    icon_class: "CSS classes for the icon SVG.",
+    icon_src: "Map of strategy names to icon sources."
 
   @moduledoc """
   Generates a sign-in button for OAuth2.
@@ -40,9 +41,13 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
   @impl true
   @spec render(props) :: Rendered.t() | no_return
   def render(assigns) do
+    strategy_name = assigns.strategy.name
+    icon_src = override_for(assigns.overrides, :icon_src)[strategy_name]
+
     assigns =
       assigns
       |> assign(:subject_name, Info.authentication_subject_name!(assigns.strategy.resource))
+      |> assign(:icon_src, icon_src)
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:gettext_fn, fn -> nil end)
       |> assign_new(:auth_routes_prefix, fn -> nil end)
@@ -53,7 +58,7 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
         href={auth_path(@socket, @subject_name, @auth_routes_prefix, @strategy, :request)}
         class={override_for(@overrides, :link_class)}
       >
-        <.icon icon={@strategy.icon} overrides={@overrides} />
+        <.icon icon={@strategy.icon} overrides={@overrides} icon_src={@icon_src} />
         {_gettext("Sign in with #{strategy_name(@strategy)}")}
       </a>
     </div>
@@ -62,8 +67,12 @@ defmodule AshAuthentication.Phoenix.Components.OAuth2 do
 
   def icon(assigns) do
     ~H"""
-    <%= if @icon do %>
-      {raw(icon_svg(@icon, override_for(@overrides, :icon_class)))}
+    <%= if @icon_src do %>
+      <img src={@icon_src} class={override_for(@overrides, :icon_class)} alt="" />
+    <% else %>
+      <%= if @icon do %>
+        {raw(icon_svg(@icon, override_for(@overrides, :icon_class)))}
+      <% end %>
     <% end %>
     """
   end

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -187,6 +187,8 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :link_class, "btn btn-outline btn-block"
 
     set :icon_class, "-ml-0.4 mr-2 h-4 w-4"
+
+    set :icon_src, nil
   end
 
   override Components.Apple do

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -219,6 +219,8 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     """
 
     set :icon_class, "-ml-0.4 mr-2 h-4 w-4"
+
+    set :icon_src, nil
   end
 
   override Components.Apple do

--- a/test/oauth2_component_test.exs
+++ b/test/oauth2_component_test.exs
@@ -1,0 +1,55 @@
+defmodule AshAuthentication.Phoenix.Components.OAuth2Test do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+  import Phoenix.LiveViewTest
+
+  alias Gettext.Interpolation.Default
+  alias AshAuthentication.Phoenix.Components.OAuth2
+  alias AshAuthentication.Phoenix.Overrides.Default
+  alias AshAuthentication.Info
+
+  describe "icon_src override" do
+    defmodule TestOverridesWithIconSrc do
+      use AshAuthentication.Phoenix.Overrides
+
+      override AshAuthentication.Phoenix.Components.OAuth2 do
+        set :icon_src, %{twitch: "/twitch-icon.svg"}
+        set :icon_class, "-ml-0.4 mr-2 h-4 w-4"
+        set :root_class, "w-full"
+        set :link_class, "btn"
+      end
+    end
+
+    test "renders custom icon source when icon_src override is provided" do
+      strategy = Info.strategy!(Example.Accounts.User, :twitch)
+
+      assigns = %{
+        strategy: strategy,
+        overrides: [TestOverridesWithIconSrc],
+        auth_routes_prefix: "/auth"
+      }
+
+      html = render_component(OAuth2, assigns)
+
+      assert html =~ ~s(<img src="/twitch-icon.svg")
+      assert html =~ ~s(class="-ml-0.4 mr-2 h-4 w-4")
+      refute html =~ "<svg"
+    end
+
+    test "falls back to default SVG icon when icon_src override is not provided" do
+      strategy = Info.strategy!(Example.Accounts.User, :twitch)
+
+      assigns = %{
+        strategy: strategy,
+        overrides: [Default],
+        auth_routes_prefix: "/auth"
+      }
+
+      html = render_component(OAuth2, assigns)
+
+      refute html =~ "<img"
+      assert html =~ "<svg"
+    end
+  end
+end

--- a/test/support/accounts/user.ex
+++ b/test/support/accounts/user.ex
@@ -52,6 +52,22 @@ defmodule Example.Accounts.User do
       end
     end
 
+    create :register_with_twitch do
+      argument :user_info, :map, allow_nil?: false
+      argument :oauth_tokens, :map, allow_nil?: false
+      upsert? true
+      upsert_identity :unique_email
+
+      change AshAuthentication.GenerateTokenChange
+
+      change fn changeset, _ ->
+        user_info = Ash.Changeset.get_argument(changeset, :user_info)
+
+        changeset
+        |> Ash.Changeset.change_attribute(:email, user_info["email"])
+      end
+    end
+
     create :register_with_slack do
       argument :user_info, :map, allow_nil?: false
       argument :oauth_tokens, :map, allow_nil?: false
@@ -142,6 +158,13 @@ defmodule Example.Accounts.User do
         client_id &get_config/2
         redirect_uri &get_config/2
         client_secret &get_config/2
+      end
+
+      oidc :twitch do
+        client_id(&get_config/2)
+        redirect_uri(&get_config/2)
+        client_secret(&get_config/2)
+        base_url(&get_config/2)
       end
 
       magic_link do


### PR DESCRIPTION
This PR adds 'icon_src' override that allows to set Oauth2/OIDC icons.
Fixes #659

Seems to be working
```ex
# in my project
defmodule StreampaiWeb.AuthOverrides do
  use AshAuthentication.Phoenix.Overrides

  override AshAuthentication.Phoenix.Components.Banner do
    set :image_url, "/images/logo-black.png"
  end

  override AshAuthentication.Phoenix.Components.OAuth2 do
    set :icon_src, %{
      twitch: "/images/twitch-logo.svg"
    }
  end
end
```
<img width="540" height="702" alt="image" src="https://github.com/user-attachments/assets/5576502d-e260-4b29-a749-afa7bd6226ff" />

