### PR TITLE
fix: update Apple component to use auth_path helper for Phoenix 1.7+ …

### DIFF
--- a/lib/ash_authentication_phoenix/components/apple.ex
+++ b/lib/ash_authentication_phoenix/components/apple.ex
@@ -16,6 +16,7 @@ defmodule AshAuthentication.Phoenix.Components.Apple do
 
     * `strategy` - The strategy configuration as per
       `AshAuthentication.Info.strategy/2`.  Required.
+    * `auth_routes_prefix` - Optional route prefix for authentication routes.
     * `overrides` - A list of override modules.
     * `gettext_fn` - Optional text translation function.
 
@@ -25,11 +26,12 @@ defmodule AshAuthentication.Phoenix.Components.Apple do
   use AshAuthentication.Phoenix.Web, :live_component
   alias AshAuthentication.{Info, Strategy}
   alias Phoenix.LiveView.Rendered
-  import AshAuthentication.Phoenix.Components.Helpers, only: [route_helpers: 1]
+  import AshAuthentication.Phoenix.Components.Helpers, only: [auth_path: 6]
   import Phoenix.HTML, only: [raw: 1]
 
   @type props :: %{
           required(:strategy) => AshAuthentication.Strategy.t(),
+          optional(:auth_routes_prefix) => String.t(),
           optional(:overrides) => [module],
           optional(:gettext_fn) => {module, atom}
         }
@@ -43,16 +45,12 @@ defmodule AshAuthentication.Phoenix.Components.Apple do
       |> assign(:subject_name, Info.authentication_subject_name!(assigns.strategy.resource))
       |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
       |> assign_new(:gettext_fn, fn -> nil end)
+      |> assign_new(:auth_routes_prefix, fn -> nil end)
 
     ~H"""
     <div class={override_for(@overrides, :root_class)}>
       <a
-        href={
-          route_helpers(@socket).auth_path(
-            @socket.endpoint,
-            {@subject_name, Strategy.name(@strategy), :request}
-          )
-        }
+        href={auth_path(@socket, @subject_name, @auth_routes_prefix, @strategy, :request, %{})}
         class={override_for(@overrides, :link_class)}
       >
         <.icon icon={:apple_white} overrides={@overrides} />


### PR DESCRIPTION
…compatibility

The Apple Sign In component was still using the deprecated route_helpers pattern while other components (OAuth2, Password) had been updated to use the auth_path helper with auth_routes_prefix support. This change brings the Apple component in line with the other authentication components, ensuring compatibility with Phoenix 1.7+ applications that don't have router helpers enabled.

Changes:
- Replace route_helpers import with auth_path helper import
- Add auth_routes_prefix to component assigns with nil default
- Add auth_routes_prefix to the @type props definition for consistency
- Document auth_routes_prefix in the moduledoc Props section
- Update href generation to use auth_path with all required parameters

This maintains backward compatibility while enabling support for Phoenix 1.7+ verified routes.