### PR TITLE
fix: String.to_existing_atom -> String.to_atom in on_mount hook

### DIFF
--- a/lib/ash_authentication_phoenix/live_session.ex
+++ b/lib/ash_authentication_phoenix/live_session.ex
@@ -179,7 +179,7 @@ defmodule AshAuthentication.Phoenix.LiveSession do
     )
     |> Enum.reduce_while(socket, fn
       {resource, true, subject_name}, socket ->
-        current_subject_name = String.to_existing_atom("current_#{subject_name}")
+        current_subject_name = String.to_atom("current_#{subject_name}")
         token_resource = Info.authentication_tokens_token_resource!(resource)
         session_key = "#{subject_name}_token"
 
@@ -196,7 +196,7 @@ defmodule AshAuthentication.Phoenix.LiveSession do
         end
 
       {resource, false, subject_name}, socket ->
-        current_subject_name = String.to_existing_atom("current_#{subject_name}")
+        current_subject_name = String.to_atom("current_#{subject_name}")
 
         with subject when is_binary(subject) <- session[subject_name],
              {:ok, subject} <- split_identifier(subject, resource) do


### PR DESCRIPTION
Just after deploys we are seeing this error in production, which is most likely caused by the fact that the instance has yet to process a regular http request, where the `:load_from_session` plug calls `AshAuthentication.Plug.Helpers.retrieve_from_session`, which then in turn dynamically creates these atoms in this function:

```elixir
defp current_subject_name(subject_name) when is_atom(subject_name),
    do: String.to_atom("current_#{subject_name}")
```

Since `AshAuthentication.Phoenix.LiveSession.on_mount` is basically the "socket equivalent" of `retrieve_from_session`, there is no risk in letting it also dynamically create the same atoms.

```
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an already existing atom

:erlang.binary_to_existing_atom("...")

lib/ash_authentication_phoenix/live_session.ex:182 anonymous fn/5 in AshAuthentication.Phoenix.LiveSession.on_mount/4

lib/stream.ex:1761 anonymous fn/3 in Enumerable.Stream.reduce/3

lib/enum.ex:4968 Enumerable.List.reduce/3

lib/stream.ex:1773 Enumerable.Stream.do_each/4

lib/enum.ex:2600 Enum.reduce_while/3

lib/ash_authentication_phoenix/live_session.ex:180 AshAuthentication.Phoenix.LiveSession.on_mount/4

lib/phoenix_live_view/lifecycle.ex:158 anonymous fn/4 in Phoenix.LiveView.Lifecycle.mount/3

lib/phoenix_live_view/lifecycle.ex:237 Phoenix.LiveView.Lifecycle.reduce_socket/3

lib/phoenix_live_view/utils.ex:346 anonymous fn/6 in Phoenix.LiveView.Utils.maybe_call_live_view_mount!/5

/app/deps/telemetry/src/telemetry.erl:324 :telemetry.span/3

lib/phoenix_live_view/channel.ex:1236 Phoenix.LiveView.Channel.verified_mount/8

lib/phoenix_live_view/channel.ex:84 Phoenix.LiveView.Channel.handle_info/2

gen_server.erl:2345 :gen_server.try_handle_info/3

gen_server.erl:2433 :gen_server.handle_msg/6

proc_lib.erl:329 :proc_lib.init_p_do_apply/3
```