### PR TITLE
fix white-on-white password input

### DIFF
--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -181,19 +181,18 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     @base_input_class """
     appearance-none block w-full px-3 py-2 border rounded-md
     shadow-sm placeholder-gray-400 focus:outline-none sm:text-sm
-    dark:text-white
     """
 
     set :input_class,
         @base_input_class <>
           """
-          border-gray-300 focus:ring-blue-400 focus:border-blue-500
+          border-gray-300 focus:ring-blue-400 focus:border-blue-500 dark:text-black
           """
 
     set :input_class_with_error,
         @base_input_class <>
           """
-          border-red-400 focus:border-red-400 focus:ring-red-300
+          border-red-400 focus:border-red-400 focus:ring-red-300 dark:text-white
           """
 
     set :submit_class, """


### PR DESCRIPTION
This fixes #649 

The input box itself, even in dark mode, is still white so the text also being white is suboptimal.