### PR TITLE
fix: allow passing in the resource for reset

### DIFF
--- a/lib/ash_authentication_phoenix/components/reset.ex
+++ b/lib/ash_authentication_phoenix/components/reset.ex
@@ -38,7 +38,8 @@ defmodule AshAuthentication.Phoenix.Components.Reset do
           required(:token) => String.t(),
           optional(:overrides) => [module],
           optional(:current_tenant) => term(),
-          optional(:gettext_fn) => {module, atom}
+          optional(:gettext_fn) => {module, atom},
+          optional(:resources) => [module]
         }
 
   @doc false
@@ -48,9 +49,12 @@ defmodule AshAuthentication.Phoenix.Components.Reset do
     socket = assign(socket, assigns)
 
     strategies =
-      socket
-      |> otp_app_from_socket()
-      |> AshAuthentication.authenticated_resources()
+      socket.assigns[:resources]
+      |> Kernel.||(
+        socket
+        |> otp_app_from_socket()
+        |> AshAuthentication.authenticated_resources()
+      )
       |> Enum.sort_by(&Info.authentication_subject_name!/1)
       |> Stream.flat_map(&Info.authentication_strategies/1)
       |> Stream.filter(&is_struct(&1, Password))

--- a/lib/ash_authentication_phoenix/reset_live.ex
+++ b/lib/ash_authentication_phoenix/reset_live.ex
@@ -39,6 +39,7 @@ defmodule AshAuthentication.Phoenix.ResetLive do
       |> assign(:context, session["context"] || %{})
       |> assign(:auth_routes_prefix, session["auth_routes_prefix"])
       |> assign(:gettext_fn, session["gettext_fn"])
+      |> assign(:resources, session["resources"])
 
     {:ok, socket}
   end
@@ -66,6 +67,7 @@ defmodule AshAuthentication.Phoenix.ResetLive do
         current_tenant={@current_tenant}
         context={@context}
         gettext_fn={@gettext_fn}
+        resources={@resources}
       />
     </div>
     """

--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -383,6 +383,8 @@ defmodule AshAuthentication.Phoenix.Router do
     each output text of the live view.
   * `gettext_backend` as a `{module :: module, domain :: String.t()}` tuple pointing to a Gettext backend module
     and specifying the Gettext domain. This is basically a convenience wrapper around `gettext_fn`.
+  * `resources` - Which resources should have their sign in UIs rendered. Defaults to all resources
+    that use `AshAuthentication`.
 
   All other options are passed to the generated `scope`.
   """
@@ -410,6 +412,7 @@ defmodule AshAuthentication.Phoenix.Router do
     {auth_routes_prefix, opts} = Keyword.pop(opts, :auth_routes_prefix)
     {gettext_fn, opts} = Keyword.pop(opts, :gettext_fn)
     {gettext_backend, opts} = Keyword.pop(opts, :gettext_backend)
+    {resources, opts} = Keyword.pop(opts, :resources)
 
     {overrides, opts} =
       Keyword.pop(opts, :overrides, [AshAuthentication.Phoenix.Overrides.Default])
@@ -451,7 +454,8 @@ defmodule AshAuthentication.Phoenix.Router do
                  "auth_routes_prefix" => auth_routes_prefix,
                  "overrides" => unquote(overrides),
                  "gettext_fn" => unquote(gettext_fn),
-                 "otp_app" => unquote(otp_app)
+                 "otp_app" => unquote(otp_app),
+                 "resources" => unquote(resources)
                }
              ]},
           on_mount: on_mount


### PR DESCRIPTION
fixes a bug where if you have mutliple ash_authentication resources, you’d have multiple reset forms rendered