### PR TITLE
feat: add convention-named Phoenix strategy tasks for auth integration

### DIFF
--- a/documentation/tutorials/totp-2fa.md
+++ b/documentation/tutorials/totp-2fa.md
@@ -60,7 +60,7 @@ defmodule MyApp.Accounts.User do
     attribute :email, :ci_string, allow_nil?: false
     attribute :hashed_password, :string, allow_nil?: true, sensitive?: true
     attribute :totp_secret, :binary, allow_nil?: true, sensitive?: true
-    attribute :last_totp_at, :utc_datetime, allow_nil?: true, sensitive?: true
+    attribute :last_totp_at, :datetime, allow_nil?: true, sensitive?: true
   end
 end
 ```
@@ -78,41 +78,44 @@ defmodule MyAppWeb.Router do
   use MyAppWeb, :router
   use AshAuthentication.Phoenix.Router
 
-  scope "/auth", MyAppWeb do
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {MyAppWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+    plug :load_from_session
+    plug :set_actor, :user
+  end
+
+  scope "/", MyAppWeb do
     pipe_through :browser
 
     # Standard auth routes
-    auth_routes AuthController, MyApp.Accounts.User, path: "/"
+    auth_routes AuthController, MyApp.Accounts.User, path: "/auth"
 
     # TOTP verification route - defaults to /totp-verify
-    totp_2fa_route MyApp.Accounts.User, :totp
-  end
-end
-```
-
-Options:
-- `path` - The path to mount at (default: `/totp-verify`)
-- `live_view` - Custom LiveView module (default: `AshAuthentication.Phoenix.TotpVerifyLive`)
-- `auth_routes_prefix` - Prefix for auth routes (e.g., `"/auth"`)
-- `overrides` - Override modules for customisation
-
-### totp_setup_route
-
-Generates a TOTP setup page for users to configure two-factor authentication on their account. This should be protected by authentication middleware.
-
-```elixir
-defmodule MyAppWeb.Router do
-  use MyAppWeb, :router
-  use AshAuthentication.Phoenix.Router
-
-  scope "/auth", MyAppWeb do
-    pipe_through [:browser, :require_authenticated_user]
+    totp_2fa_route MyApp.Accounts.User, :totp, auth_routes_prefix: "/auth"
 
     # TOTP setup route - defaults to /totp-setup
-    totp_setup_route MyApp.Accounts.User, :totp
+    totp_setup_route MyApp.Accounts.User, :totp, auth_routes_prefix: "/auth"
   end
 end
 ```
+
+> ### Browser pipeline {: .info}
+>
+> The `plug :set_actor, :user` is required in the browser pipeline for TOTP
+> verification to work. The `load_from_session` plug loads the user from the
+> session into `conn.assigns`, and `set_actor` makes it available to the TOTP
+> verify action via `Ash.PlugHelpers.get_actor/1`.
+
+Options for both macros:
+- `path` - The path to mount at (defaults to `/totp-verify` and `/totp-setup`)
+- `live_view` - Custom LiveView module
+- `auth_routes_prefix` - Prefix for auth routes (e.g., `"/auth"`). **Required** for the form action URLs to work correctly.
+- `overrides` - Override modules for customisation
 
 Options:
 - `path` - The path to mount at (default: `/totp-setup`)
@@ -120,28 +123,9 @@ Options:
 - `auth_routes_prefix` - Prefix for auth routes
 - `overrides` - Override modules for customisation
 
-### Route Ordering
+### Automatic Route Insertion
 
-When using `auth_routes` alongside custom TOTP routes, route ordering matters. The `auth_routes` macro generates catch-all routes that may intercept requests intended for other routes. Define specific routes **before** `auth_routes`, or place them in a separate scope:
-
-```elixir
-scope "/auth", MyAppWeb do
-  pipe_through :browser
-
-  # Define specific routes FIRST
-  totp_2fa_route MyApp.Accounts.User, :totp, path: "/totp/verify"
-
-  # Then auth_routes (which has catch-all patterns)
-  auth_routes AuthController, MyApp.Accounts.User, path: "/"
-end
-
-# Or use a separate scope for TOTP setup (requires authentication)
-scope "/auth", MyAppWeb do
-  pipe_through [:browser, :require_authenticated_user]
-
-  totp_setup_route MyApp.Accounts.User, :totp, path: "/totp/setup"
-end
-```
+When using the igniter installer (`mix igniter.install ash_authentication_phoenix --auth-strategy totp`), the TOTP routes are automatically added to your router's browser scope alongside the other auth routes. You can also add them manually to an existing project.
 
 ## Requiring TOTP for Routes
 
@@ -222,182 +206,80 @@ on_mount: [{AshAuthentication.Phoenix.LiveSession.RequireTotp,
 | `setup_path` | Path to redirect for TOTP setup | `"/auth/totp/setup"` |
 | `current_user_assign` | Assign key for current user | `:current_user` |
 
-## Hard-Required 2FA with Auth Controller
+## 2FA with Auth Controller
 
-For applications that require TOTP verification immediately after password sign-in (before accessing any authenticated route), use a custom auth controller callback combined with session tracking.
+When using the igniter installer with `--auth-strategy magic_link,totp` (or `password,totp`), the TOTP strategy task automatically generates auth controller clauses that handle the 2FA flow. Here's how the generated code works:
 
-### Custom Auth Controller
+### Generated Auth Controller Clauses
 
-Override the `success/4` callback to check TOTP status after password authentication:
+The installer adds two `success/4` clauses before the default catch-all:
 
 ```elixir
 defmodule MyAppWeb.AuthController do
   use MyAppWeb, :controller
   use AshAuthentication.Phoenix.Controller
 
-  alias AshAuthentication.Phoenix.TotpHelpers
+  # Sign-in interception: check if TOTP is configured
+  def success(conn, {_, phase} = _activity, user, token)
+      when phase in [:sign_in, :sign_in_with_token] do
+    return_to = get_session(conn, :return_to) || ~p"/"
 
-  def success(conn, {:password, _strategy}, user, _token) do
-    if TotpHelpers.totp_configured?(user) do
-      conn
-      |> put_session(:awaiting_totp_verification, true)
-      |> put_session(:totp_user_id, user.id)
-      |> redirect(to: ~p"/auth/totp/verify")
-    else
+    if AshAuthentication.Phoenix.TotpHelpers.totp_configured?(user) do
+      # TOTP is set up — store user in session and redirect to verify
       conn
       |> store_in_session(user)
+      |> set_live_socket_id(token)
       |> assign(:current_user, user)
-      |> redirect(to: ~p"/")
-    end
-  end
-
-  def success(conn, {:totp, _strategy}, user, _token) do
-    conn
-    |> delete_session(:awaiting_totp_verification)
-    |> delete_session(:totp_user_id)
-    |> store_in_session(user)
-    |> assign(:current_user, user)
-    |> redirect(to: ~p"/")
-  end
-
-  def success(conn, _activity, user, _token) do
-    conn
-    |> store_in_session(user)
-    |> assign(:current_user, user)
-    |> redirect(to: ~p"/")
-  end
-
-  def failure(conn, _activity, _reason) do
-    conn
-    |> put_flash(:error, "Authentication failed")
-    |> redirect(to: ~p"/sign-in")
-  end
-
-  def sign_out(conn, _params) do
-    conn
-    |> clear_session()
-    |> redirect(to: ~p"/")
-  end
-end
-```
-
-### Companion Plug for TOTP Verification
-
-Create a plug that blocks access until TOTP is verified:
-
-```elixir
-defmodule MyAppWeb.Plugs.RequireTotpVerification do
-  import Plug.Conn
-  import Phoenix.Controller
-
-  def init(opts), do: opts
-
-  def call(conn, _opts) do
-    cond do
-      get_session(conn, :awaiting_totp_verification) ->
-        conn
-        |> put_flash(:info, "Please verify your identity")
-        |> redirect(to: "/auth/totp/verify")
-        |> halt()
-
-      true ->
-        conn
-    end
-  end
-end
-```
-
-### Router Configuration
-
-Use the plug in your authenticated pipeline:
-
-```elixir
-defmodule MyAppWeb.Router do
-  use MyAppWeb, :router
-  use AshAuthentication.Phoenix.Router
-
-  pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_live_flash
-    plug :put_root_layout, html: {MyAppWeb.Layouts, :root}
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-    plug :load_from_session
-  end
-
-  pipeline :require_totp_verified do
-    plug MyAppWeb.Plugs.RequireTotpVerification
-  end
-
-  scope "/auth", MyAppWeb do
-    pipe_through :browser
-
-    auth_routes AuthController, MyApp.Accounts.User, path: "/"
-
-    # TOTP verify page must be accessible during verification
-    get "/totp/verify", TotpVerifyController, :show
-    post "/totp/verify", TotpVerifyController, :verify
-  end
-
-  scope "/", MyAppWeb do
-    pipe_through [:browser, :require_authenticated, :require_totp_verified]
-
-    # All protected routes
-    get "/", PageController, :home
-    get "/dashboard", DashboardController, :index
-  end
-end
-```
-
-### TOTP Verify Controller
-
-```elixir
-defmodule MyAppWeb.TotpVerifyController do
-  use MyAppWeb, :controller
-
-  alias AshAuthentication.Info
-
-  def show(conn, _params) do
-    if get_session(conn, :awaiting_totp_verification) do
-      render(conn, :verify)
+      |> put_session(:return_to, return_to)
+      |> redirect(to: ~p"/totp-verify/#{token}")
     else
-      redirect(conn, to: ~p"/")
+      # No TOTP configured — redirect to setup
+      conn
+      |> store_in_session(user)
+      |> set_live_socket_id(token)
+      |> assign(:current_user, user)
+      |> put_session(:return_to, return_to)
+      |> redirect(to: ~p"/totp-setup")
     end
   end
 
-  def verify(conn, %{"code" => code}) do
-    user_id = get_session(conn, :totp_user_id)
-    {:ok, user} = MyApp.Accounts.get_user_by_id(user_id)
-    {:ok, strategy} = Info.strategy(user.__struct__, :totp)
+  # Registration: always redirect to TOTP setup
+  def success(conn, {_, :register}, user, token) do
+    return_to = get_session(conn, :return_to) || ~p"/"
 
-    case AshAuthentication.Strategy.action(strategy, :sign_in, %{
-      strategy.identity_field => Map.get(user, strategy.identity_field),
-      :code => code
-    }) do
-      {:ok, verified_user} ->
-        conn
-        |> delete_session(:awaiting_totp_verification)
-        |> delete_session(:totp_user_id)
-        |> store_in_session(verified_user)
-        |> assign(:current_user, verified_user)
-        |> redirect(to: ~p"/")
-
-      {:error, _} ->
-        conn
-        |> put_flash(:error, "Invalid code")
-        |> redirect(to: ~p"/auth/totp/verify")
-    end
+    conn
+    |> store_in_session(user)
+    |> set_live_socket_id(token)
+    |> assign(:current_user, user)
+    |> put_session(:return_to, return_to)
+    |> redirect(to: ~p"/totp-setup")
   end
+
+  # Default catch-all for other auth activities
+  def success(conn, activity, user, token) do
+    # ... standard success handling
+  end
+
+  # ...
 end
 ```
 
-This pattern ensures that:
+### How the flow works
 
-1. Password authentication succeeds but doesn't grant full access
-2. The user is redirected to TOTP verification
-3. All protected routes check for completed TOTP verification
-4. Only after TOTP verification does the user get full session access
+1. **Sign-in**: When a user signs in (via password or magic link), the first clause matches `:sign_in` or `:sign_in_with_token`. It stores the user in session, then checks if TOTP is configured:
+   - **TOTP configured**: redirects to `/totp-verify/:token` where the built-in `TotpVerifyLive` presents the code entry form
+   - **TOTP not configured**: redirects to `/totp-setup` where the built-in `TotpSetupLive` shows the QR code setup flow
+
+2. **Registration**: New users (e.g., via magic link with `registration_enabled? true`) match the `:register` clause and are always redirected to TOTP setup.
+
+3. **TOTP verification**: The user is already in the session (so `plug :load_from_session` and `plug :set_actor, :user` find them). The verify form submits to the TOTP strategy's verify action, which checks the code. On success, the controller's catch-all `success/4` runs and redirects to the return path.
+
+> ### Why store_in_session before verify? {: .info}
+>
+> The user is stored in session before TOTP verification so that the verify
+> plug can find the user via `get_actor(conn)`. The `RequireTotp` plug or
+> LiveView hook can be used on protected routes to ensure TOTP verification
+> has been completed before granting access to sensitive resources.
 
 ## Authentication Metadata
 

--- a/lib/ash_authentication_phoenix/components/totp/setup_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/setup_form.ex
@@ -236,19 +236,24 @@ if Code.ensure_loaded?(EQRCode) do
 
     def handle_event("confirm", params, socket) do
       params = get_params(params, socket.assigns.strategy)
+      code = Map.get(params, "code", "") |> String.trim()
 
-      params =
-        params
-        |> Map.put("setup_token", socket.assigns.setup_token)
+      cond do
+        not Regex.match?(~r/^\d{6}$/, code) ->
+          form = Form.validate(socket.assigns.form, params)
+          {:noreply, assign(socket, form: form)}
 
-      form = Form.validate(socket.assigns.form, params)
+        not valid_totp_code?(socket.assigns.totp_url, code, socket.assigns.strategy) ->
+          form = Form.validate(socket.assigns.form, params)
 
-      socket =
-        socket
-        |> assign(:form, form)
-        |> assign(:trigger_action, form.valid?)
+          {:noreply,
+           assign(socket, form: form, error: "Invalid authentication code. Please try again.")}
 
-      {:noreply, socket}
+        true ->
+          params = Map.put(params, "setup_token", socket.assigns.setup_token)
+          form = Form.validate(socket.assigns.form, params)
+          {:noreply, assign(socket, form: form, error: nil, trigger_action: true)}
+      end
     end
 
     defp build_confirm_form(socket) do
@@ -298,6 +303,27 @@ if Code.ensure_loaded?(EQRCode) do
     end
 
     defp generate_qr_svg(_), do: nil
+
+    defp valid_totp_code?(totp_url, code, strategy) when is_binary(totp_url) do
+      uri = URI.parse(totp_url)
+      query = URI.decode_query(uri.query || "")
+
+      case Base.decode32(query["secret"] || "", padding: false) do
+        {:ok, secret} ->
+          period = String.to_integer(query["period"] || "30")
+          grace_period = Map.get(strategy, :grace_period) || 0
+          time = System.os_time(:second)
+
+          Enum.any?(0..grace_period, fn i ->
+            NimbleTOTP.valid?(secret, code, period: period, time: time - i * period)
+          end)
+
+        _ ->
+          false
+      end
+    end
+
+    defp valid_totp_code?(_, _, _), do: false
 
     defp validate_code_format(code) when is_binary(code) do
       code = String.trim(code)

--- a/lib/ash_authentication_phoenix/components/totp/setup_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/setup_form.ex
@@ -2,338 +2,346 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshAuthentication.Phoenix.Components.Totp.SetupForm do
-  unless Code.ensure_loaded?(EQRCode) do
-    raise CompileError,
-      description: """
-      The TOTP setup form requires the `eqrcode` library for QR code generation.
+if Code.ensure_loaded?(EQRCode) do
+  defmodule AshAuthentication.Phoenix.Components.Totp.SetupForm do
+    use AshAuthentication.Phoenix.Overrides.Overridable,
+      root_class: "CSS class for the root `div` element.",
+      label_class: "CSS class for the `h2` element.",
+      instructions_class: "CSS class for setup instructions text.",
+      instructions_text: "Instructions text shown above QR code.",
+      qr_code_class: "CSS class for the QR code container.",
+      qr_code_wrapper_class: "CSS class for the wrapper around QR code and instructions.",
+      form_class: "CSS class for the `form` element.",
+      slot_class: "CSS class for the `div` surrounding the slot.",
+      button_text: "Text for the submit button.",
+      disable_button_text: "Text for the submit button when the request is happening.",
+      setup_button_text: "Text for the initial setup button.",
+      setup_button_class: "CSS class for the initial setup button.",
+      error_class: "CSS class for error messages."
 
-      Please add it to your dependencies in mix.exs:
+    @moduledoc """
+    Generates a setup form for TOTP authentication with QR code display.
 
-          {:eqrcode, "~> 0.1"}
+    This component handles the complete TOTP setup flow:
 
-      Then run `mix deps.get` to install it.
-      """
-  end
+    1. Shows a "Set up" button
+    2. When clicked, calls the setup action to generate a secret
+    3. Displays the QR code and code input field
+    4. Validates the code (format only for confirmation mode)
+    5. Confirms setup when user submits valid code
 
-  use AshAuthentication.Phoenix.Overrides.Overridable,
-    root_class: "CSS class for the root `div` element.",
-    label_class: "CSS class for the `h2` element.",
-    instructions_class: "CSS class for setup instructions text.",
-    instructions_text: "Instructions text shown above QR code.",
-    qr_code_class: "CSS class for the QR code container.",
-    qr_code_wrapper_class: "CSS class for the wrapper around QR code and instructions.",
-    form_class: "CSS class for the `form` element.",
-    slot_class: "CSS class for the `div` surrounding the slot.",
-    button_text: "Text for the submit button.",
-    disable_button_text: "Text for the submit button when the request is happening.",
-    setup_button_text: "Text for the initial setup button.",
-    setup_button_class: "CSS class for the initial setup button.",
-    error_class: "CSS class for error messages."
+    ## Requirements
 
-  @moduledoc """
-  Generates a setup form for TOTP authentication with QR code display.
+    This component requires the `eqrcode` library for QR code generation.
+    Add it to your dependencies:
 
-  This component handles the complete TOTP setup flow:
+        {:eqrcode, "~> 0.1"}
 
-  1. Shows a "Set up" button
-  2. When clicked, calls the setup action to generate a secret
-  3. Displays the QR code and code input field
-  4. Validates the code (format only for confirmation mode)
-  5. Confirms setup when user submits valid code
+    ## Component hierarchy
 
-  ## Requirements
+    This is a child of `AshAuthentication.Phoenix.Components.Totp`.
 
-  This component requires the `eqrcode` library for QR code generation.
-  Add it to your dependencies:
+    Children:
 
-      {:eqrcode, "~> 0.1"}
+      * `AshAuthentication.Phoenix.Components.Totp.Input.code_field/1`
+      * `AshAuthentication.Phoenix.Components.Totp.Input.submit/1`
 
-  ## Component hierarchy
+    ## Props
 
-  This is a child of `AshAuthentication.Phoenix.Components.Totp`.
+      * `strategy` - The configuration map as per
+        `AshAuthentication.Info.strategy/2`. Required.
+      * `label` - The text to show in the submit label. Generated from the
+        configured action name (via `Phoenix.Naming.humanize/1`) if not supplied.
+        Set to `false` to disable.
+      * `overrides` - A list of override modules.
+      * `gettext_fn` - Optional text translation function.
 
-  Children:
-
-    * `AshAuthentication.Phoenix.Components.Totp.Input.code_field/1`
-    * `AshAuthentication.Phoenix.Components.Totp.Input.submit/1`
-
-  ## Props
-
-    * `strategy` - The configuration map as per
-      `AshAuthentication.Info.strategy/2`. Required.
-    * `label` - The text to show in the submit label. Generated from the
-      configured action name (via `Phoenix.Naming.humanize/1`) if not supplied.
-      Set to `false` to disable.
-    * `overrides` - A list of override modules.
-    * `gettext_fn` - Optional text translation function.
-
-  #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
-  """
-
-  use AshAuthentication.Phoenix.Web, :live_component
-  alias AshAuthentication.{Info, Phoenix.Components.Totp, Strategy}
-  alias AshPhoenix.Form
-  alias Phoenix.LiveView.{Rendered, Socket}
-
-  import AshAuthentication.Phoenix.Components.Helpers,
-    only: [auth_path: 5]
-
-  import Phoenix.HTML.Form
-  import PhoenixHTMLHelpers.Form
-  import Slug
-
-  @type props :: %{
-          required(:strategy) => AshAuthentication.Strategy.t(),
-          optional(:label) => String.t() | false,
-          optional(:current_tenant) => String.t(),
-          optional(:context) => map(),
-          optional(:auth_routes_prefix) => String.t(),
-          optional(:overrides) => [module],
-          optional(:gettext_fn) => {module, atom}
-        }
-
-  @doc false
-  @impl true
-  @spec update(props, Socket.t()) :: {:ok, Socket.t()}
-  def update(assigns, socket) do
-    strategy = assigns.strategy
-    subject_name = Info.authentication_subject_name!(strategy.resource)
-
-    socket =
-      socket
-      |> assign(assigns)
-      |> assign(subject_name: subject_name)
-      |> assign_new(:label, fn -> humanize(strategy.setup_action_name) end)
-      |> assign_new(:inner_block, fn -> nil end)
-      |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
-      |> assign_new(:gettext_fn, fn -> nil end)
-      |> assign_new(:current_tenant, fn -> nil end)
-      |> assign_new(:context, fn -> %{} end)
-      |> assign_new(:auth_routes_prefix, fn -> nil end)
-      |> assign_new(:setup_token, fn -> nil end)
-      |> assign_new(:totp_url, fn -> nil end)
-      |> assign_new(:qr_svg, fn -> nil end)
-      |> assign_new(:code_valid, fn -> nil end)
-      |> assign_new(:error, fn -> nil end)
-
-    socket =
-      if socket.assigns.setup_token do
-        build_confirm_form(socket)
-      else
-        assign(socket, form: nil, trigger_action: false)
-      end
-
-    {:ok, socket}
-  end
-
-  @doc false
-  @impl true
-  @spec render(Socket.assigns()) :: Rendered.t() | no_return
-  def render(assigns) do
-    ~H"""
-    <div class={override_for(@overrides, :root_class)}>
-      <%= if @label do %>
-        <h2 class={override_for(@overrides, :label_class)}>{_gettext(@label)}</h2>
-      <% end %>
-
-      <%= if @error do %>
-        <div class={override_for(@overrides, :error_class)}>
-          {_gettext(@error)}
-        </div>
-      <% end %>
-
-      <%= if @setup_token && @qr_svg do %>
-        <div class={override_for(@overrides, :qr_code_wrapper_class)}>
-          <p class={override_for(@overrides, :instructions_class)}>
-            {_gettext(override_for(@overrides, :instructions_text))}
-          </p>
-          <div class={override_for(@overrides, :qr_code_class)}>
-            {Phoenix.HTML.raw(@qr_svg)}
-          </div>
-        </div>
-
-        <.form
-          :let={form}
-          for={@form}
-          id={@form.id}
-          phx-change="change"
-          phx-submit="confirm"
-          phx-trigger-action={@trigger_action}
-          phx-target={@myself}
-          action={auth_path(@socket, @subject_name, @auth_routes_prefix, @strategy, :confirm_setup)}
-          method="POST"
-          class={override_for(@overrides, :form_class)}
-        >
-          <input type="hidden" name={input_name(form, :setup_token)} value={@setup_token} />
-
-          <Totp.Input.code_field
-            strategy={@strategy}
-            form={form}
-            code_valid={@code_valid}
-            overrides={@overrides}
-            gettext_fn={@gettext_fn}
-          />
-
-          <%= if @inner_block do %>
-            <div class={override_for(@overrides, :slot_class)}>
-              {render_slot(@inner_block, form)}
-            </div>
-          <% end %>
-
-          <Totp.Input.submit
-            strategy={@strategy}
-            id={@form.id <> "-submit"}
-            form={form}
-            action={:confirm_setup}
-            label={override_for(@overrides, :button_text)}
-            disable_text={override_for(@overrides, :disable_button_text)}
-            overrides={@overrides}
-            gettext_fn={@gettext_fn}
-          />
-        </.form>
-      <% else %>
-        <button
-          type="button"
-          phx-click="setup"
-          phx-target={@myself}
-          class={override_for(@overrides, :setup_button_class)}
-        >
-          {_gettext(override_for(@overrides, :setup_button_text))}
-        </button>
-      <% end %>
-    </div>
+    #{AshAuthentication.Phoenix.Overrides.Overridable.generate_docs()}
     """
+
+    use AshAuthentication.Phoenix.Web, :live_component
+    alias AshAuthentication.{Info, Phoenix.Components.Totp, Strategy}
+    alias AshPhoenix.Form
+    alias Phoenix.LiveView.{Rendered, Socket}
+
+    import AshAuthentication.Phoenix.Components.Helpers,
+      only: [auth_path: 5]
+
+    import Phoenix.HTML.Form
+    import PhoenixHTMLHelpers.Form
+    import Slug
+
+    @type props :: %{
+            required(:strategy) => AshAuthentication.Strategy.t(),
+            optional(:label) => String.t() | false,
+            optional(:current_tenant) => String.t(),
+            optional(:context) => map(),
+            optional(:auth_routes_prefix) => String.t(),
+            optional(:overrides) => [module],
+            optional(:gettext_fn) => {module, atom}
+          }
+
+    @doc false
+    @impl true
+    @spec update(props, Socket.t()) :: {:ok, Socket.t()}
+    def update(assigns, socket) do
+      strategy = assigns.strategy
+      subject_name = Info.authentication_subject_name!(strategy.resource)
+
+      socket =
+        socket
+        |> assign(assigns)
+        |> assign(subject_name: subject_name)
+        |> assign_new(:label, fn -> humanize(strategy.setup_action_name) end)
+        |> assign_new(:inner_block, fn -> nil end)
+        |> assign_new(:overrides, fn -> [AshAuthentication.Phoenix.Overrides.Default] end)
+        |> assign_new(:gettext_fn, fn -> nil end)
+        |> assign_new(:current_tenant, fn -> nil end)
+        |> assign_new(:context, fn -> %{} end)
+        |> assign_new(:auth_routes_prefix, fn -> nil end)
+        |> assign_new(:setup_token, fn -> nil end)
+        |> assign_new(:totp_url, fn -> nil end)
+        |> assign_new(:qr_svg, fn -> nil end)
+        |> assign_new(:code_valid, fn -> nil end)
+        |> assign_new(:error, fn -> nil end)
+
+      socket =
+        if socket.assigns.setup_token do
+          build_confirm_form(socket)
+        else
+          assign(socket, form: nil, trigger_action: false)
+        end
+
+      {:ok, socket}
+    end
+
+    @doc false
+    @impl true
+    @spec render(Socket.assigns()) :: Rendered.t() | no_return
+    def render(assigns) do
+      ~H"""
+      <div class={override_for(@overrides, :root_class)}>
+        <%= if @label do %>
+          <h2 class={override_for(@overrides, :label_class)}>{_gettext(@label)}</h2>
+        <% end %>
+
+        <%= if @error do %>
+          <div class={override_for(@overrides, :error_class)}>
+            {_gettext(@error)}
+          </div>
+        <% end %>
+
+        <%= if @setup_token && @qr_svg do %>
+          <div class={override_for(@overrides, :qr_code_wrapper_class)}>
+            <p class={override_for(@overrides, :instructions_class)}>
+              {_gettext(override_for(@overrides, :instructions_text))}
+            </p>
+            <div class={override_for(@overrides, :qr_code_class)}>
+              {Phoenix.HTML.raw(@qr_svg)}
+            </div>
+          </div>
+
+          <.form
+            :let={form}
+            for={@form}
+            id={@form.id}
+            phx-change="change"
+            phx-submit="confirm"
+            phx-trigger-action={@trigger_action}
+            phx-target={@myself}
+            action={auth_path(@socket, @subject_name, @auth_routes_prefix, @strategy, :confirm_setup)}
+            method="POST"
+            class={override_for(@overrides, :form_class)}
+          >
+            <input type="hidden" name={input_name(form, :setup_token)} value={@setup_token} />
+
+            <Totp.Input.code_field
+              strategy={@strategy}
+              form={form}
+              code_valid={@code_valid}
+              overrides={@overrides}
+              gettext_fn={@gettext_fn}
+            />
+
+            <%= if @inner_block do %>
+              <div class={override_for(@overrides, :slot_class)}>
+                {render_slot(@inner_block, form)}
+              </div>
+            <% end %>
+
+            <Totp.Input.submit
+              strategy={@strategy}
+              id={@form.id <> "-submit"}
+              form={form}
+              action={:confirm_setup}
+              label={override_for(@overrides, :button_text)}
+              disable_text={override_for(@overrides, :disable_button_text)}
+              overrides={@overrides}
+              gettext_fn={@gettext_fn}
+            />
+          </.form>
+        <% else %>
+          <button
+            type="button"
+            phx-click="setup"
+            phx-target={@myself}
+            class={override_for(@overrides, :setup_button_class)}
+          >
+            {_gettext(override_for(@overrides, :setup_button_text))}
+          </button>
+        <% end %>
+      </div>
+      """
+    end
+
+    @doc false
+    @impl true
+    @spec handle_event(String.t(), %{required(String.t()) => String.t()}, Socket.t()) ::
+            {:noreply, Socket.t()}
+
+    def handle_event("setup", _params, socket) do
+      strategy = socket.assigns.strategy
+      user = socket.assigns[:current_user]
+
+      case call_setup_action(strategy, user, socket.assigns) do
+        {:ok, user_with_metadata} ->
+          setup_token = Ash.Resource.get_metadata(user_with_metadata, :setup_token)
+          totp_url = Ash.Resource.get_metadata(user_with_metadata, :totp_url)
+          qr_svg = generate_qr_svg(totp_url)
+
+          socket =
+            socket
+            |> assign(setup_token: setup_token, totp_url: totp_url, qr_svg: qr_svg, error: nil)
+            |> build_confirm_form()
+
+          {:noreply, socket}
+
+        {:error, error} ->
+          {:noreply, assign(socket, error: format_error(error))}
+      end
+    end
+
+    def handle_event("change", params, socket) do
+      params = get_params(params, socket.assigns.strategy)
+      code = Map.get(params, "code", "")
+
+      code_valid = validate_code_format(code)
+
+      form =
+        socket.assigns.form
+        |> Form.validate(params, errors: false)
+
+      {:noreply, assign(socket, form: form, code_valid: code_valid)}
+    end
+
+    def handle_event("confirm", params, socket) do
+      params = get_params(params, socket.assigns.strategy)
+
+      params =
+        params
+        |> Map.put("setup_token", socket.assigns.setup_token)
+
+      form = Form.validate(socket.assigns.form, params)
+
+      socket =
+        socket
+        |> assign(:form, form)
+        |> assign(:trigger_action, form.valid?)
+
+      {:noreply, socket}
+    end
+
+    defp build_confirm_form(socket) do
+      strategy = socket.assigns.strategy
+      domain = Info.authentication_domain!(strategy.resource)
+      subject_name = socket.assigns.subject_name
+
+      context =
+        Ash.Helpers.deep_merge_maps(socket.assigns[:context] || %{}, %{
+          strategy: strategy,
+          private: %{ash_authentication?: true}
+        })
+
+      form =
+        strategy.resource
+        |> Form.for_action(strategy.confirm_setup_action_name,
+          domain: domain,
+          as: subject_name |> to_string() |> slugify(),
+          id:
+            "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.confirm_setup_action_name}"
+            |> slugify(),
+          tenant: socket.assigns[:current_tenant],
+          context: context
+        )
+
+      assign(socket, form: form, trigger_action: false)
+    end
+
+    defp call_setup_action(strategy, user, assigns) when not is_nil(user) do
+      options = [
+        tenant: assigns[:current_tenant]
+      ]
+
+      Strategy.action(strategy, :setup, %{user: user}, options)
+    end
+
+    defp call_setup_action(_strategy, nil, _assigns) do
+      {:error, "User must be signed in to set up TOTP"}
+    end
+
+    defp generate_qr_svg(totp_url) when is_binary(totp_url) do
+      totp_url
+      |> EQRCode.encode()
+      |> EQRCode.svg(width: 200)
+    rescue
+      _ -> nil
+    end
+
+    defp generate_qr_svg(_), do: nil
+
+    defp validate_code_format(code) when is_binary(code) do
+      code = String.trim(code)
+
+      cond do
+        code == "" -> nil
+        Regex.match?(~r/^\d{6}$/, code) -> true
+        true -> false
+      end
+    end
+
+    defp validate_code_format(_), do: nil
+
+    defp get_params(params, strategy) do
+      param_key =
+        strategy.resource
+        |> Info.authentication_subject_name!()
+        |> to_string()
+        |> slugify()
+
+      Map.get(params, param_key, %{})
+    end
+
+    defp format_error(%{message: message}), do: message
+    defp format_error(message) when is_binary(message), do: message
+    defp format_error(_), do: "An error occurred during setup"
   end
+else
+  defmodule AshAuthentication.Phoenix.Components.Totp.SetupForm do
+    @moduledoc false
 
-  @doc false
-  @impl true
-  @spec handle_event(String.t(), %{required(String.t()) => String.t()}, Socket.t()) ::
-          {:noreply, Socket.t()}
+    use Phoenix.LiveComponent
 
-  def handle_event("setup", _params, socket) do
-    strategy = socket.assigns.strategy
-    user = socket.assigns[:current_user]
+    @eqrcode_message "The TOTP setup form requires the eqrcode library. Add {:eqrcode, \"~> 0.1\"} to your dependencies."
 
-    case call_setup_action(strategy, user, socket.assigns) do
-      {:ok, user_with_metadata} ->
-        setup_token = Ash.Resource.get_metadata(user_with_metadata, :setup_token)
-        totp_url = Ash.Resource.get_metadata(user_with_metadata, :totp_url)
-        qr_svg = generate_qr_svg(totp_url)
+    @impl true
+    def render(assigns) do
+      assigns = Phoenix.Component.assign(assigns, :message, @eqrcode_message)
 
-        socket =
-          socket
-          |> assign(setup_token: setup_token, totp_url: totp_url, qr_svg: qr_svg, error: nil)
-          |> build_confirm_form()
-
-        {:noreply, socket}
-
-      {:error, error} ->
-        {:noreply, assign(socket, error: format_error(error))}
+      ~H"""
+      <div>
+        <p>{@message}</p>
+      </div>
+      """
     end
   end
-
-  def handle_event("change", params, socket) do
-    params = get_params(params, socket.assigns.strategy)
-    code = Map.get(params, "code", "")
-
-    code_valid = validate_code_format(code)
-
-    form =
-      socket.assigns.form
-      |> Form.validate(params, errors: false)
-
-    {:noreply, assign(socket, form: form, code_valid: code_valid)}
-  end
-
-  def handle_event("confirm", params, socket) do
-    params = get_params(params, socket.assigns.strategy)
-
-    params =
-      params
-      |> Map.put("setup_token", socket.assigns.setup_token)
-
-    form = Form.validate(socket.assigns.form, params)
-
-    socket =
-      socket
-      |> assign(:form, form)
-      |> assign(:trigger_action, form.valid?)
-
-    {:noreply, socket}
-  end
-
-  defp build_confirm_form(socket) do
-    strategy = socket.assigns.strategy
-    domain = Info.authentication_domain!(strategy.resource)
-    subject_name = socket.assigns.subject_name
-
-    context =
-      Ash.Helpers.deep_merge_maps(socket.assigns[:context] || %{}, %{
-        strategy: strategy,
-        private: %{ash_authentication?: true}
-      })
-
-    form =
-      strategy.resource
-      |> Form.for_action(strategy.confirm_setup_action_name,
-        domain: domain,
-        as: subject_name |> to_string() |> slugify(),
-        id:
-          "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.confirm_setup_action_name}"
-          |> slugify(),
-        tenant: socket.assigns[:current_tenant],
-        context: context
-      )
-
-    assign(socket, form: form, trigger_action: false)
-  end
-
-  defp call_setup_action(strategy, user, assigns) when not is_nil(user) do
-    options = [
-      tenant: assigns[:current_tenant]
-    ]
-
-    Strategy.action(strategy, :setup, %{user: user}, options)
-  end
-
-  defp call_setup_action(_strategy, nil, _assigns) do
-    {:error, "User must be signed in to set up TOTP"}
-  end
-
-  defp generate_qr_svg(totp_url) when is_binary(totp_url) do
-    totp_url
-    |> EQRCode.encode()
-    |> EQRCode.svg(width: 200)
-  rescue
-    _ -> nil
-  end
-
-  defp generate_qr_svg(_), do: nil
-
-  defp validate_code_format(code) when is_binary(code) do
-    code = String.trim(code)
-
-    cond do
-      code == "" -> nil
-      Regex.match?(~r/^\d{6}$/, code) -> true
-      true -> false
-    end
-  end
-
-  defp validate_code_format(_), do: nil
-
-  defp get_params(params, strategy) do
-    param_key =
-      strategy.resource
-      |> Info.authentication_subject_name!()
-      |> to_string()
-      |> slugify()
-
-    Map.get(params, param_key, %{})
-  end
-
-  defp format_error(%{message: message}), do: message
-  defp format_error(message) when is_binary(message), do: message
-  defp format_error(_), do: "An error occurred during setup"
 end

--- a/lib/ash_authentication_phoenix/components/totp/verify_2fa_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/verify_2fa_form.ex
@@ -239,10 +239,16 @@ defmodule AshAuthentication.Phoenix.Components.Totp.Verify2faForm do
 
     form = Form.validate(socket.assigns.form, params)
 
+    # The form's valid? check includes the :user argument which is a struct
+    # injected by the plug on the server side, not submitted by the form.
+    # We validate the code format ourselves instead.
+    code = Map.get(params, "code", "")
+    code_valid? = Regex.match?(~r/^\d{6}$/, String.trim(code))
+
     socket =
       socket
       |> assign(:form, form)
-      |> assign(:trigger_action, form.valid?)
+      |> assign(:trigger_action, code_valid?)
 
     {:noreply, socket}
   end

--- a/lib/ash_authentication_phoenix/token_revocation_notifier.ex
+++ b/lib/ash_authentication_phoenix/token_revocation_notifier.ex
@@ -52,7 +52,7 @@ defmodule AshAuthentication.Phoenix.TokenRevocationNotifier do
         resource: token_resource
       }) do
     with {:ok, template_fn} <- Info.token_live_socket_id_template(token_resource),
-         socket_id <- template_fn.(data),
+         socket_id <- template_fn.(Map.delete(data, :__struct__)),
          {:ok, endpoints} when endpoints != [] <- Info.token_endpoints(token_resource) do
       Enum.each(endpoints, fn endpoint ->
         endpoint.broadcast(socket_id, "disconnect", %{})

--- a/lib/mix/tasks/ash_authentication_phoenix.add_add_on.confirmation.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_add_on.confirmation.ex
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddAddOn.Confirmation do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication_phoenix.add_add_on.confirmation"
+
+    @shortdoc "Adds Phoenix integration for the email confirmation add-on"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Upgrades the confirmation sender to use Swoosh and Phoenix verified routes
+    when available.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field
+        ],
+        defaults: [
+          identity_field: "email"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+      sender = Module.concat(options[:user], Senders.SendNewUserConfirmationEmail)
+
+      upgrade_sender(igniter, sender, options)
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &maybe_parse_module/1)
+      |> Keyword.update!(:user, &maybe_parse_module/1)
+    end
+
+    defp maybe_parse_module(value) when is_binary(value), do: Igniter.Project.Module.parse(value)
+    defp maybe_parse_module(value), do: value
+
+    defp upgrade_sender(igniter, sender, _options) do
+      case Igniter.Libs.Swoosh.list_mailers(igniter) do
+        {igniter, [mailer]} ->
+          web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+          contents =
+            """
+            defmodule #{inspect(sender)} do
+              @moduledoc \"\"\"
+              Sends an email for a new user to confirm their email address.
+              \"\"\"
+
+              use AshAuthentication.Sender
+              use #{inspect(web_module)}, :verified_routes
+
+              import Swoosh.Email
+
+              alias #{inspect(mailer)}
+
+              @impl true
+              def send(user, token, _) do
+                new()
+                |> from({"noreply", "noreply@example.com"})
+                |> to(to_string(user.email))
+                |> subject("Confirm your email address")
+                |> html_body(body([token: token]))
+                |> #{List.last(Module.split(mailer))}.deliver!()
+              end
+
+              defp body(params) do
+                url = url(~p"/confirm_new_user/\#{params[:token]}")
+
+                \"\"\"
+                <p>Click this link to confirm your email:</p>
+                <p><a href="\#{url}">\#{url}</a></p>
+                \"\"\"
+              end
+            end
+            """
+
+          location =
+            Igniter.Project.Module.proper_location(igniter, sender)
+
+          Igniter.create_new_file(igniter, location, contents, on_exists: :overwrite)
+
+        _ ->
+          igniter
+      end
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddAddOn.Confirmation do
+    @shortdoc "Adds Phoenix integration for the email confirmation add-on"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication_phoenix.add_add_on.confirmation' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication_phoenix.add_strategy.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_strategy.ex
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication_phoenix.add_strategy password"
+
+    @shortdoc "Adds a strategy to your user resource with Phoenix integration"
+
+    @aa_strategy_tasks %{
+      "password" => "ash_authentication.add_strategy.password",
+      "magic_link" => "ash_authentication.add_strategy.magic_link",
+      "api_key" => "ash_authentication.add_strategy.api_key",
+      "totp" => "ash_authentication.add_strategy.totp"
+    }
+
+    @aap_strategy_tasks %{
+      "password" => "ash_authentication_phoenix.add_strategy.password",
+      "magic_link" => "ash_authentication_phoenix.add_strategy.magic_link",
+      "totp" => "ash_authentication_phoenix.add_strategy.totp"
+    }
+
+    @strategy_names Map.keys(@aa_strategy_tasks)
+
+    @strategy_explanation [
+                            password:
+                              "Register and sign in with a username/email and a password.",
+                            magic_link:
+                              "Register and sign in with a magic link, sent via email to the user.",
+                            api_key: "Sign in with an API key.",
+                            totp: "Authenticate with a time-based one-time password (TOTP)."
+                          ]
+                          |> Enum.map_join("\n", fn {name, description} ->
+                            "  * `#{name}` - #{description}"
+                          end)
+
+    @moduledoc """
+    #{@shortdoc}
+
+    This task composes both the ash_authentication resource-level task and the
+    ash_authentication_phoenix Phoenix integration task for each strategy.
+
+    The following strategies are available:
+
+    #{@strategy_explanation}
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--identity-field`, `-i` - The identity field. Defaults to `email`
+
+    ## Password options
+
+      - `--hash-provider` - The hash provider to use, either `bcrypt` or `argon2`. Defaults to `bcrypt`.
+
+    ## TOTP options
+
+      - `--mode`, `-m` - Either `primary` or `2fa`. Defaults to `2fa`.
+      - `--name`, `-n` - The name of the TOTP strategy. Defaults to `totp`.
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [
+          strategies: [rest: true]
+        ],
+        composes: Map.values(@aa_strategy_tasks) ++ Map.values(@aap_strategy_tasks),
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          hash_provider: :string,
+          mode: :string,
+          name: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field,
+          m: :mode,
+          n: :name
+        ],
+        defaults: [
+          identity_field: "email"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      strategies = igniter.args.positional[:strategies] || []
+
+      invalid_strategy = Enum.find(strategies, &(&1 not in @strategy_names))
+
+      if invalid_strategy do
+        Mix.shell().error("""
+        Invalid strategy provided: `#{invalid_strategy}`
+
+        Available Strategies:
+
+        #{@strategy_explanation}
+        """)
+
+        exit({:shutdown, 1})
+      end
+
+      argv = igniter.args.argv_flags
+
+      Enum.reduce(strategies, igniter, fn strategy, igniter ->
+        igniter
+        |> maybe_compose(strategy, @aa_strategy_tasks, argv)
+        |> maybe_compose(strategy, @aap_strategy_tasks, argv)
+      end)
+    end
+
+    defp maybe_compose(igniter, strategy, task_map, argv) do
+      case Map.fetch(task_map, strategy) do
+        {:ok, task} -> Igniter.compose_task(igniter, task, argv)
+        :error -> igniter
+      end
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy do
+    @shortdoc "Adds a strategy to your user resource with Phoenix integration"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication_phoenix.add_strategy' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication_phoenix.add_strategy.magic_link.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_strategy.magic_link.ex
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.MagicLink do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication_phoenix.add_strategy magic_link"
+
+    @shortdoc "Adds Phoenix integration for the magic link authentication strategy"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Upgrades the magic link sender to use Swoosh and Phoenix verified routes
+    when available.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field
+        ],
+        defaults: [
+          identity_field: "email"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+      sender = Module.concat(options[:user], Senders.SendMagicLinkEmail)
+
+      upgrade_sender(igniter, sender, options)
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &maybe_parse_module/1)
+      |> Keyword.update!(:user, &maybe_parse_module/1)
+    end
+
+    defp maybe_parse_module(value) when is_binary(value), do: Igniter.Project.Module.parse(value)
+    defp maybe_parse_module(value), do: value
+
+    defp upgrade_sender(igniter, sender, _options) do
+      case Igniter.Libs.Swoosh.list_mailers(igniter) do
+        {igniter, [mailer]} ->
+          web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+          contents =
+            """
+            defmodule #{inspect(sender)} do
+              @moduledoc \"\"\"
+              Sends a magic link email
+              \"\"\"
+
+              use AshAuthentication.Sender
+              use #{inspect(web_module)}, :verified_routes
+
+              import Swoosh.Email
+              alias #{inspect(mailer)}
+
+              @impl true
+              def send(user_or_email, token, _) do
+                email =
+                  case user_or_email do
+                    %{email: email} -> email
+                    email -> email
+                  end
+
+                new()
+                |> from({"noreply", "noreply@example.com"})
+                |> to(to_string(email))
+                |> subject("Your login link")
+                |> html_body(body([token: token, email: email]))
+                |> #{List.last(Module.split(mailer))}.deliver!()
+              end
+
+              defp body(params) do
+                url = url(~p"/magic_link/\#{params[:token]}")
+
+                \"\"\"
+                <p>Hello, \#{params[:email]}! Click this link to sign in:</p>
+                <p><a href="\#{url}">\#{url}</a></p>
+                \"\"\"
+              end
+            end
+            """
+
+          location =
+            Igniter.Project.Module.proper_location(igniter, sender)
+
+          Igniter.create_new_file(igniter, location, contents, on_exists: :overwrite)
+
+        _ ->
+          igniter
+      end
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.MagicLink do
+    @shortdoc "Adds Phoenix integration for the magic link authentication strategy"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication_phoenix.add_strategy.magic_link' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication_phoenix.add_strategy.password.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_strategy.password.ex
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.Password do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication_phoenix.add_strategy password"
+
+    @shortdoc "Adds Phoenix integration for the password authentication strategy"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Upgrades the password reset sender to use Swoosh and Phoenix verified routes
+    when available.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        composes: [
+          "ash_authentication_phoenix.add_add_on.confirmation"
+        ],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field
+        ],
+        defaults: [
+          identity_field: "email"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+      sender = Module.concat(options[:user], Senders.SendPasswordResetEmail)
+
+      igniter
+      |> upgrade_sender(sender, options)
+      |> maybe_compose_confirmation(options)
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &maybe_parse_module/1)
+      |> Keyword.update!(:user, &maybe_parse_module/1)
+    end
+
+    defp maybe_parse_module(value) when is_binary(value), do: Igniter.Project.Module.parse(value)
+    defp maybe_parse_module(value), do: value
+
+    defp upgrade_sender(igniter, sender, _options) do
+      case Igniter.Libs.Swoosh.list_mailers(igniter) do
+        {igniter, [mailer]} ->
+          web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+          contents =
+            """
+            defmodule #{inspect(sender)} do
+              @moduledoc \"\"\"
+              Sends a password reset email
+              \"\"\"
+
+              use AshAuthentication.Sender
+              use #{inspect(web_module)}, :verified_routes
+
+              import Swoosh.Email
+
+              alias #{inspect(mailer)}
+
+              @impl true
+              def send(user, token, _) do
+                new()
+                |> from({"noreply", "noreply@example.com"})
+                |> to(to_string(user.email))
+                |> subject("Reset your password")
+                |> html_body(body([token: token]))
+                |> #{List.last(Module.split(mailer))}.deliver!()
+              end
+
+              defp body(params) do
+                url = url(~p"/password-reset/\#{params[:token]}")
+
+                \"\"\"
+                <p>Click this link to reset your password:</p>
+                <p><a href="\#{url}">\#{url}</a></p>
+                \"\"\"
+              end
+            end
+            """
+
+          location =
+            Igniter.Project.Module.proper_location(igniter, sender)
+
+          Igniter.create_new_file(igniter, location, contents, on_exists: :overwrite)
+
+        _ ->
+          igniter
+      end
+    end
+
+    defp maybe_compose_confirmation(igniter, options) do
+      if options[:identity_field] == :email do
+        Igniter.compose_task(
+          igniter,
+          "ash_authentication_phoenix.add_add_on.confirmation",
+          [
+            "--user",
+            inspect(options[:user]),
+            "--identity-field",
+            to_string(options[:identity_field])
+          ]
+        )
+      else
+        igniter
+      end
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.Password do
+    @shortdoc "Adds Phoenix integration for the password authentication strategy"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication_phoenix.add_strategy.password' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication_phoenix.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_strategy.totp.ex
@@ -103,16 +103,26 @@ if Code.ensure_loaded?(Igniter) do
       if router do
         user = inspect(options[:user])
         strategy_name = inspect(options[:name])
+        overrides = Igniter.Libs.Phoenix.web_module_name(igniter, "AuthOverrides")
+
+        override_module =
+          if Igniter.exists?(igniter, "assets/vendor/daisyui.js") do
+            AshAuthentication.Phoenix.Overrides.DaisyUI
+          else
+            AshAuthentication.Phoenix.Overrides.Default
+          end
+
+        overrides_opt = "overrides: [#{inspect(overrides)}, #{inspect(override_module)}]"
 
         routes =
           if options[:mode] == :"2fa" do
             """
-            totp_2fa_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
-            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
+            totp_2fa_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth", #{overrides_opt}
+            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth", #{overrides_opt}
             """
           else
             """
-            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
+            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth", #{overrides_opt}
             """
           end
 

--- a/lib/mix/tasks/ash_authentication_phoenix.add_strategy.totp.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.add_strategy.totp.ex
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.Totp do
+    use Igniter.Mix.Task
+
+    @example "mix ash_authentication_phoenix.add_strategy totp"
+
+    @shortdoc "Adds Phoenix integration for the TOTP authentication strategy"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Modifies the AuthController to handle TOTP 2FA redirects and emits
+    route setup instructions.
+
+    This task is typically composed by `ash_authentication_phoenix.add_strategy`
+    or the `ash_authentication_phoenix.install` task. It can also be run directly
+    to add TOTP Phoenix integration to an existing project.
+
+    ## Example
+
+    ```bash
+    #{@example}
+    ```
+
+    ## Options
+
+    * `--user`, `-u` - The user resource. Defaults to `YourApp.Accounts.User`
+    * `--mode`, `-m` - Either `primary` or `2fa`. Defaults to `2fa`.
+    * `--name`, `-n` - The name of the TOTP strategy. Defaults to `totp`.
+    """
+
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        group: :ash,
+        example: @example,
+        extra_args?: false,
+        only: nil,
+        positional: [],
+        schema: [
+          accounts: :string,
+          user: :string,
+          identity_field: :string,
+          mode: :string,
+          name: :string
+        ],
+        aliases: [
+          a: :accounts,
+          u: :user,
+          i: :identity_field,
+          m: :mode,
+          n: :name
+        ],
+        defaults: [
+          identity_field: "email",
+          mode: "2fa",
+          name: "totp"
+        ]
+      }
+    end
+
+    def igniter(igniter) do
+      options = parse_options(igniter)
+
+      igniter
+      |> Igniter.Project.Deps.add_dep({:eqrcode, "~> 0.1"})
+      |> add_totp_routes(options)
+      |> maybe_modify_controller(options)
+    end
+
+    defp parse_options(igniter) do
+      options =
+        igniter.args.options
+        |> Keyword.put_new_lazy(:accounts, fn ->
+          Igniter.Project.Module.module_name(igniter, "Accounts")
+        end)
+
+      options
+      |> Keyword.put_new_lazy(:user, fn ->
+        Module.concat(options[:accounts], User)
+      end)
+      |> Keyword.update(:identity_field, :email, &String.to_atom/1)
+      |> Keyword.update(:mode, :"2fa", &String.to_atom/1)
+      |> Keyword.update(:name, :totp, &String.to_atom/1)
+      |> Keyword.update!(:accounts, &maybe_parse_module/1)
+      |> Keyword.update!(:user, &maybe_parse_module/1)
+    end
+
+    defp maybe_parse_module(value) when is_binary(value), do: Igniter.Project.Module.parse(value)
+    defp maybe_parse_module(value), do: value
+
+    defp add_totp_routes(igniter, options) do
+      {igniter, router} =
+        Igniter.Libs.Phoenix.select_router(
+          igniter,
+          "Which Phoenix router should be modified for TOTP routes?"
+        )
+
+      if router do
+        user = inspect(options[:user])
+        strategy_name = inspect(options[:name])
+
+        routes =
+          if options[:mode] == :"2fa" do
+            """
+            totp_2fa_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
+            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
+            """
+          else
+            """
+            totp_setup_route #{user}, #{strategy_name}, auth_routes_prefix: "/auth"
+            """
+          end
+
+        Igniter.Libs.Phoenix.append_to_scope(
+          igniter,
+          "/",
+          routes,
+          with_pipelines: [:browser],
+          arg2: Igniter.Libs.Phoenix.web_module(igniter),
+          router: router
+        )
+      else
+        igniter
+      end
+    end
+
+    defp maybe_modify_controller(igniter, options) do
+      if options[:mode] == :"2fa" do
+        modify_controller_for_2fa(igniter)
+      else
+        igniter
+      end
+    end
+
+    defp modify_controller_for_2fa(igniter) do
+      web_module = Igniter.Libs.Phoenix.web_module(igniter)
+      controller = Module.concat(web_module, AuthController)
+
+      {exists?, igniter} = Igniter.Project.Module.module_exists(igniter, controller)
+
+      if exists? do
+        replace_controller_success(igniter, controller)
+      else
+        Igniter.add_warning(igniter, """
+        Could not find AuthController at #{inspect(controller)}.
+
+        You will need to manually update your auth controller's success/4 function
+        to handle TOTP 2FA redirects. See the TOTP tutorial for details.
+        """)
+      end
+    end
+
+    defp replace_controller_success(igniter, controller) do
+      Igniter.Project.Module.find_and_update_module!(igniter, controller, fn zipper ->
+        case Igniter.Code.Function.move_to_def(zipper, :success, 4, target: :at) do
+          {:ok, zipper} -> maybe_insert_totp_clauses(zipper)
+          _ -> {:ok, zipper}
+        end
+      end)
+    end
+
+    defp maybe_insert_totp_clauses(zipper) do
+      if has_totp_clauses?(zipper) do
+        {:ok, zipper}
+      else
+        {:ok, Igniter.Code.Common.add_code(zipper, totp_clauses(), placement: :before)}
+      end
+    end
+
+    defp totp_clauses do
+      totp_sign_in_clause() <> "\n" <> totp_registration_clause()
+    end
+
+    defp has_totp_clauses?(zipper) do
+      zipper
+      |> Sourceror.Zipper.topmost()
+      |> Igniter.Code.Common.move_to(fn z ->
+        Igniter.Code.Function.function_call?(z, :def, [2, 3, 4]) and
+          source_contains_totp_guard?(z)
+      end)
+      |> case do
+        {:ok, _} -> true
+        :error -> false
+      end
+    end
+
+    defp source_contains_totp_guard?(zipper) do
+      source = Sourceror.Zipper.node(zipper) |> Macro.to_string()
+      String.contains?(source, "when phase in [:sign_in, :sign_in_with_token]")
+    end
+
+    defp totp_sign_in_clause do
+      ~S"""
+      def success(conn, {_, phase} = _activity, user, token)
+          when phase in [:sign_in, :sign_in_with_token] do
+        return_to = get_session(conn, :return_to) || ~p"/"
+
+        if AshAuthentication.Phoenix.TotpHelpers.totp_configured?(user) do
+          conn
+          |> store_in_session(user)
+          |> set_live_socket_id(token)
+          |> assign(:current_user, user)
+          |> put_session(:return_to, return_to)
+          |> redirect(to: ~p"/totp-verify/#{token}")
+        else
+          conn
+          |> store_in_session(user)
+          |> set_live_socket_id(token)
+          |> assign(:current_user, user)
+          |> put_session(:return_to, return_to)
+          |> redirect(to: ~p"/totp-setup")
+        end
+      end
+      """
+    end
+
+    defp totp_registration_clause do
+      ~S"""
+      def success(conn, {_, :register}, user, token) do
+        return_to = get_session(conn, :return_to) || ~p"/"
+
+        conn
+        |> store_in_session(user)
+        |> set_live_socket_id(token)
+        |> assign(:current_user, user)
+        |> put_session(:return_to, return_to)
+        |> redirect(to: ~p"/totp-setup")
+      end
+      """
+    end
+  end
+else
+  defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.Totp do
+    @shortdoc "Adds Phoenix integration for the TOTP authentication strategy"
+
+    @moduledoc @shortdoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_authentication_phoenix.add_strategy.totp' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -27,6 +27,12 @@ if Code.ensure_loaded?(Igniter) do
     * `--token` or `-t` - The resource that represents a token. Defaults to `<accounts>.Token`.
     """
 
+    @phoenix_strategy_tasks %{
+      "password" => "ash_authentication_phoenix.add_strategy.password",
+      "magic_link" => "ash_authentication_phoenix.add_strategy.magic_link",
+      "totp" => "ash_authentication_phoenix.add_strategy.totp"
+    }
+
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
         example: @example,
@@ -36,15 +42,22 @@ if Code.ensure_loaded?(Igniter) do
           user: :string,
           token: :string,
           yes: :boolean,
-          auth_strategy: :string
+          auth_strategy: :csv,
+          mode: :string,
+          name: :string
         ],
-        composes: ["ash_authentication.install"],
+        composes:
+          ["ash_authentication.install"] ++
+            Map.values(@phoenix_strategy_tasks) ++
+            ["ash_authentication_phoenix.add_add_on.confirmation"],
         aliases: [
           s: :auth_strategy,
           a: :accounts,
           u: :user,
           t: :token,
-          y: :yes
+          y: :yes,
+          m: :mode,
+          n: :name
         ]
       }
     end
@@ -88,7 +101,6 @@ if Code.ensure_loaded?(Igniter) do
                 yes_to_deps: true
               )
           end)
-          |> Igniter.compose_task("ash_authentication.install", argv)
         else
           igniter
         end
@@ -110,15 +122,25 @@ if Code.ensure_loaded?(Igniter) do
         |> setup_routes_alias()
         |> warn_on_missing_modules(options, argv, install?)
         |> do_or_explain_tailwind_changes()
+        # Create Phoenix scaffolding before composing AA, so strategy tasks
+        # can see the controller (e.g. TOTP modifies AuthController)
         |> create_auth_controller(otp_app)
         |> create_overrides_module(overrides)
-        |> add_auth_routes(overrides, options, router, web_module)
         |> create_live_user_auth(web_module)
+        # Compose AA install if it hasn't already been run (i.e. fresh install).
+        # When AA was already installed, its install task ran in a prior pass
+        # and its output is already on disk.
+        |> maybe_compose_aa_install(install?, argv)
+        # Apply Phoenix-specific strategy integration (sender upgrades, controller mods)
+        |> compose_phoenix_strategy_tasks(options)
+        |> add_auth_routes(overrides, options, router, web_module)
         |> configure_token_resource_notifier(options, web_module)
       else
+        # No router — still run AA install for resource generation if it hasn't already run
         igniter
+        |> maybe_compose_aa_install(install?, argv)
         |> Igniter.add_warning("""
-        AshAuthenticationPhoenix installer could not find a Phoenix router. Skipping installation.
+        AshAuthenticationPhoenix installer could not find a Phoenix router. Skipping Phoenix setup.
 
         Set up a phoenix router and reinvoke the installer with `mix igniter.install ash_authentication_phoenix`.
         """)
@@ -160,7 +182,9 @@ if Code.ensure_loaded?(Igniter) do
 
         igniter
         |> use_authentication_phoenix_router(router)
-        |> Igniter.Libs.Phoenix.append_to_pipeline(:browser, "plug :load_from_session",
+        |> Igniter.Libs.Phoenix.append_to_pipeline(
+          :browser,
+          "plug :load_from_session\nplug :set_actor, :user",
           router: router
         )
         |> Igniter.Libs.Phoenix.append_to_pipeline(
@@ -432,8 +456,6 @@ if Code.ensure_loaded?(Igniter) do
             {:ok,
              Igniter.Code.Common.add_code(zipper, """
              use AshAuthentication.Phoenix.Router
-
-             import AshAuthentication.Plug.Helpers
              """)}
 
           _ ->
@@ -584,6 +606,23 @@ if Code.ensure_loaded?(Igniter) do
 
       Run the installer now?
       """)
+    end
+
+    defp maybe_compose_aa_install(igniter, true = _install?, argv),
+      do: Igniter.compose_task(igniter, "ash_authentication.install", argv)
+
+    defp maybe_compose_aa_install(igniter, false = _install?, _argv), do: igniter
+
+    defp compose_phoenix_strategy_tasks(igniter, options) do
+      strategies = List.wrap(options[:auth_strategy])
+      argv = igniter.args.argv_flags
+
+      Enum.reduce(strategies, igniter, fn strategy, igniter ->
+        case Map.fetch(@phoenix_strategy_tasks, to_string(strategy)) do
+          {:ok, task} -> Igniter.compose_task(igniter, task, argv)
+          :error -> igniter
+        end
+      end)
     end
 
     defp module_option(opts, name) do

--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -120,18 +120,12 @@ if Code.ensure_loaded?(Igniter) do
         |> Igniter.Project.Formatter.import_dep(:ash_authentication_phoenix)
         |> Igniter.compose_task("igniter.add_extension", ["phoenix"])
         |> setup_routes_alias()
-        |> warn_on_missing_modules(options, argv, install?)
         |> do_or_explain_tailwind_changes()
-        # Create Phoenix scaffolding before composing AA, so strategy tasks
-        # can see the controller (e.g. TOTP modifies AuthController)
         |> create_auth_controller(otp_app)
         |> create_overrides_module(overrides)
         |> create_live_user_auth(web_module)
-        # Compose AA install if it hasn't already been run (i.e. fresh install).
-        # When AA was already installed, its install task ran in a prior pass
-        # and its output is already on disk.
         |> maybe_compose_aa_install(install?, argv)
-        # Apply Phoenix-specific strategy integration (sender upgrades, controller mods)
+        |> warn_on_missing_modules(options, argv, install?)
         |> compose_phoenix_strategy_tasks(options)
         |> add_auth_routes(overrides, options, router, web_module)
         |> configure_token_resource_notifier(options, web_module)

--- a/test/mix/tasks/ash_authentication_phoenix.add_strategy.totp_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.add_strategy.totp_test.exs
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.TotpTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  setup do
+    igniter =
+      test_project()
+      |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+      |> Igniter.Project.Deps.add_dep({:ash_authentication, ">= 0.0.0"})
+      |> Igniter.Project.Formatter.add_formatter_plugin(Spark.Formatter)
+      |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+      |> Igniter.Project.Module.create_module(TestWeb.Router, """
+      @moduledoc false
+
+      use TestWeb, :router
+
+      pipeline :browser do
+        plug :accepts, ["html"]
+        plug :fetch_session
+      end
+
+      scope "/", TestWeb do
+        pipe_through :browser
+      end
+      """)
+      |> Igniter.Project.Module.create_module(TestWeb.AuthController, """
+      use TestWeb, :controller
+      use AshAuthentication.Phoenix.Controller
+
+      def success(conn, activity, user, token) do
+        return_to = get_session(conn, :return_to) || ~p"/"
+
+        message =
+          case activity do
+            {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
+            {:password, :reset} -> "Your password has successfully been reset"
+            _ -> "You are now signed in"
+          end
+
+        conn
+        |> delete_session(:return_to)
+        |> store_in_session(user)
+        |> set_live_socket_id(token)
+        |> assign(:current_user, user)
+        |> put_flash(:info, message)
+        |> redirect(to: return_to)
+      end
+
+      def failure(conn, _activity, _reason) do
+        conn
+        |> put_flash(:error, "Incorrect email or password")
+        |> redirect(to: ~p"/sign-in")
+      end
+
+      def sign_out(conn, _params) do
+        conn
+        |> redirect(to: ~p"/")
+      end
+      """)
+      |> apply_igniter!()
+
+    [igniter: igniter]
+  end
+
+  describe "2fa mode" do
+    test "inserts sign-in interception clause before existing success/4", %{
+      igniter: igniter
+    } do
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_patch("lib/test_web/auth_controller.ex", """
+      + |  def success(conn, {_, phase} = _activity, user, token)
+      + |      when phase in [:sign_in, :sign_in_with_token] do
+      """)
+    end
+
+    test "sign-in clause stores user in session before redirecting to verify", %{
+      igniter: igniter
+    } do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+
+      controller_diff = diff(result, path: "lib/test_web/auth_controller.ex")
+      assert controller_diff =~ "store_in_session(user)"
+      assert controller_diff =~ "totp-verify"
+    end
+
+    test "inserts registration redirect clause before existing success/4", %{
+      igniter: igniter
+    } do
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_patch("lib/test_web/auth_controller.ex", """
+      + |  def success(conn, {_, :register}, user, token) do
+      """)
+    end
+
+    test "does not modify the existing catch-all success clause", %{igniter: igniter} do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+
+      refute diff(result, path: "lib/test_web/auth_controller.ex") =~ "- |  def success"
+    end
+
+    test "adds totp_2fa_route and totp_setup_route to the router", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_patch("lib/test_web/router.ex", """
+      + |    totp_2fa_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      """)
+      |> assert_has_patch("lib/test_web/router.ex", """
+      + |    totp_setup_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      """)
+    end
+
+    test "is idempotent", %{igniter: igniter} do
+      igniter =
+        igniter
+        |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_unchanged("lib/test_web/auth_controller.ex")
+    end
+  end
+
+  describe "primary mode" do
+    test "does not modify controller", %{igniter: igniter} do
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", [
+        "--mode",
+        "primary"
+      ])
+      |> assert_unchanged("lib/test_web/auth_controller.ex")
+    end
+
+    test "adds only totp_setup_route to the router", %{igniter: igniter} do
+      result =
+        igniter
+        |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", [
+          "--mode",
+          "primary"
+        ])
+
+      assert_has_patch(result, "lib/test_web/router.ex", """
+      + |    totp_setup_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      """)
+
+      refute diff(result, path: "lib/test_web/router.ex") =~ "totp_2fa_route"
+    end
+  end
+
+  describe "missing controller" do
+    test "emits warning when controller does not exist" do
+      igniter =
+        test_project()
+        |> Igniter.Project.Deps.add_dep({:simple_sat, ">= 0.0.0"})
+        |> Igniter.Project.Deps.add_dep({:ash_authentication, ">= 0.0.0"})
+        |> Igniter.Project.Formatter.add_formatter_plugin(Spark.Formatter)
+        |> Igniter.compose_task("ash_authentication.install", ["--yes"])
+        |> apply_igniter!()
+
+      igniter
+      |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
+      |> assert_has_warning(&String.contains?(&1, "Could not find AuthController"))
+    end
+  end
+end

--- a/test/mix/tasks/ash_authentication_phoenix.add_strategy.totp_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.add_strategy.totp_test.exs
@@ -116,10 +116,16 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.TotpTest do
       igniter
       |> Igniter.compose_task("ash_authentication_phoenix.add_strategy.totp", ["--mode", "2fa"])
       |> assert_has_patch("lib/test_web/router.ex", """
-      + |    totp_2fa_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      + |    totp_2fa_route(Test.Accounts.User, :totp,
+      + |      auth_routes_prefix: "/auth",
+      + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+      + |    )
       """)
       |> assert_has_patch("lib/test_web/router.ex", """
-      + |    totp_setup_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      + |    totp_setup_route(Test.Accounts.User, :totp,
+      + |      auth_routes_prefix: "/auth",
+      + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+      + |    )
       """)
     end
 
@@ -154,7 +160,10 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.AddStrategy.TotpTest do
         ])
 
       assert_has_patch(result, "lib/test_web/router.ex", """
-      + |    totp_setup_route(Test.Accounts.User, :totp, auth_routes_prefix: "/auth")
+      + |    totp_setup_route(Test.Accounts.User, :totp,
+      + |      auth_routes_prefix: "/auth",
+      + |      overrides: [TestWeb.AuthOverrides, AshAuthentication.Phoenix.Overrides.Default]
+      + |    )
       """)
 
       refute diff(result, path: "lib/test_web/router.ex") =~ "totp_2fa_route"

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -241,6 +241,7 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     """)
     |> assert_has_patch("lib/test_web/router.ex", """
     + |    plug(:load_from_session)
+    + |    plug(:set_actor, :user)
     """)
     |> assert_has_patch("lib/test_web/router.ex", """
       |  pipeline :api do


### PR DESCRIPTION
## Summary

Add new igniter tasks that own Phoenix-specific integration for each authentication strategy, following the convention-routed composition pattern from `phx_install`. AA's igniters now generate only resource-level code; AAP's new strategy tasks handle senders, controller mods, and routes.

### New tasks
- `ash_authentication_phoenix.add_strategy` — orchestrator composing both AA and AAP strategy tasks
- `ash_authentication_phoenix.add_strategy.totp` — controller clause insertion, TOTP route auto-insertion, `eqrcode` dep
- `ash_authentication_phoenix.add_strategy.password` — Swoosh sender upgrade for password reset
- `ash_authentication_phoenix.add_strategy.magic_link` — Swoosh sender upgrade for magic link
- `ash_authentication_phoenix.add_add_on.confirmation` — Swoosh sender upgrade for confirmation

### Installer changes
- Restructure ordering: create controller before AA install so TOTP can modify it
- Compose AAP strategy tasks after AA install based on `--auth-strategy`
- Fix `auth_strategy: :string` → `:csv` option type
- Add `plug :set_actor, :user` to browser pipeline (required for TOTP verify flow)
- Remove redundant `import AshAuthentication.Plug.Helpers` (caused ambiguous `set_actor/2`)

### Bug fixes
- `TokenRevocationNotifier`: handle struct data in `live_socket_id_template`
- `SetupForm`: conditional compilation when `eqrcode` not available
- `Verify2faForm`: validate code format directly (`:user` struct arg can't be validated from form params)
- Generated TOTP sign-in clause: `store_in_session` before verify redirect

## Companion PR

team-alembic/ash_authentication#1145

## Test plan

- [x] `mix check --no-retry` passes (all 12 checks green including dialyzer)
- [x] 28 igniter tests pass (16 installer + 9 TOTP + 3 upgrade)
- [x] End-to-end tested with `nietflix` test app:
  - Fresh install with `--auth-strategy magic_link,totp`
  - New user registration → TOTP setup → QR code → confirm with code
  - Existing user sign-in → TOTP 2FA verify → signed in