### PR TITLE
fix: use consistent underscored subject name for form param keys

### DIFF
--- a/lib/ash_authentication_phoenix/components/confirm/form.ex
+++ b/lib/ash_authentication_phoenix/components/confirm/form.ex
@@ -161,7 +161,6 @@ defmodule AshAuthentication.Phoenix.Components.Confirm.Form do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/magic_link.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link.ex
@@ -173,7 +173,6 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -239,7 +239,6 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -189,7 +189,6 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/sign_in_form.ex
@@ -103,7 +103,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
       strategy.resource
       |> Form.for_action(strategy.sign_in_action_name,
         domain: domain,
-        as: subject_name |> to_string() |> slugify(),
+        as: subject_name |> to_string(),
         id:
           "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.sign_in_action_name}"
           |> slugify(),
@@ -250,7 +250,6 @@ defmodule AshAuthentication.Phoenix.Components.Password.SignInForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/recovery_code/verify_form.ex
+++ b/lib/ash_authentication_phoenix/components/recovery_code/verify_form.ex
@@ -97,7 +97,7 @@ defmodule AshAuthentication.Phoenix.Components.RecoveryCode.VerifyForm do
           resource
           |> Form.for_action(strategy.verify_action_name,
             domain: domain,
-            as: subject_name |> to_string() |> slugify(),
+            as: subject_name |> to_string(),
             id:
               "#{subject_name}-#{Strategy.name(strategy)}-verify-recovery-code"
               |> slugify(),
@@ -240,7 +240,6 @@ defmodule AshAuthentication.Phoenix.Components.RecoveryCode.VerifyForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -202,7 +202,6 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/totp/setup_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/setup_form.ex
@@ -271,7 +271,7 @@ if Code.ensure_loaded?(EQRCode) do
         strategy.resource
         |> Form.for_action(strategy.confirm_setup_action_name,
           domain: domain,
-          as: subject_name |> to_string() |> slugify(),
+          as: subject_name |> to_string(),
           id:
             "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.confirm_setup_action_name}"
             |> slugify(),
@@ -342,7 +342,6 @@ if Code.ensure_loaded?(EQRCode) do
         strategy.resource
         |> Info.authentication_subject_name!()
         |> to_string()
-        |> slugify()
 
       Map.get(params, param_key, %{})
     end

--- a/lib/ash_authentication_phoenix/components/totp/sign_in_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/sign_in_form.ex
@@ -88,7 +88,7 @@ defmodule AshAuthentication.Phoenix.Components.Totp.SignInForm do
       strategy.resource
       |> Form.for_action(strategy.sign_in_action_name,
         domain: domain,
-        as: subject_name |> to_string() |> slugify(),
+        as: subject_name |> to_string(),
         id:
           "#{subject_name}-#{Strategy.name(strategy)}-#{strategy.sign_in_action_name}"
           |> slugify(),
@@ -189,7 +189,6 @@ defmodule AshAuthentication.Phoenix.Components.Totp.SignInForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end

--- a/lib/ash_authentication_phoenix/components/totp/verify_2fa_form.ex
+++ b/lib/ash_authentication_phoenix/components/totp/verify_2fa_form.ex
@@ -120,7 +120,7 @@ defmodule AshAuthentication.Phoenix.Components.Totp.Verify2faForm do
           resource
           |> Form.for_action(strategy.verify_action_name,
             domain: domain,
-            as: subject_name |> to_string() |> slugify(),
+            as: subject_name |> to_string(),
             id:
               "#{subject_name}-#{Strategy.name(strategy)}-verify-2fa"
               |> slugify(),
@@ -276,7 +276,6 @@ defmodule AshAuthentication.Phoenix.Components.Totp.Verify2faForm do
       strategy.resource
       |> Info.authentication_subject_name!()
       |> to_string()
-      |> slugify()
 
     Map.get(params, param_key, %{})
   end


### PR DESCRIPTION
## Summary

- Remove `slugify()` from the `as:` option and `get_params/2` across all form components so that form param keys consistently use the underscored subject name (e.g. `"admin_user"` not `"admin-user"`)
- This matches what the ash_authentication plugs (`Password.Plug.subject_params/2`, `MagicLink.Plug.subject_params/2`) expect when extracting params via `to_string()` without slugification
- Previously, some components slugified while others didn't, causing silent param lookup failures for multi-word subject names like `AdminUser`

### Affected components

**`as:` option fixed** (was slugifying, now uses `to_string()` only):
- `Password.SignInForm`
- `Totp.Verify2faForm`
- `Totp.SetupForm`
- `Totp.SignInForm`
- `RecoveryCode.VerifyForm`

**`get_params/2` fixed** (was slugifying the lookup key):
- `Password.SignInForm`
- `Password.RegisterForm`
- `Password.ResetForm`
- `Totp.SetupForm`
- `Totp.SignInForm`
- `Totp.Verify2faForm`
- `RecoveryCode.VerifyForm`
- `Confirm.Form`
- `MagicLink`
- `Reset.Form`

Note: `slugify()` is intentionally retained on `id:` values (HTML element IDs) where hyphens are conventional.

Supersedes #727 with a more complete fix.

Closes #726

## Test plan

- [x] `mix compile` passes
- [x] `mix test` — 131 tests, 0 failures
- [ ] Manual test with a multi-word subject name (e.g. `AdminUser`) to verify sign-in, registration, password reset, and magic link forms all work end-to-end