### PR TITLE
fix: use raw paths for reset/register route definitions in sign_in_route

### DIFF
--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -414,7 +414,9 @@ defmodule AshAuthentication.Phoenix.Router do
           end
 
           if register_path do
-            live(register_route_path, unquote(live_view), :register, as: :"#{unquote(as)}_register")
+            live(register_route_path, unquote(live_view), :register,
+              as: :"#{unquote(as)}_register"
+            )
           end
         end
       end

--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -351,11 +351,25 @@ defmodule AshAuthentication.Phoenix.Router do
             value -> Phoenix.Router.scoped_path(__MODULE__, value)
           end
 
+        register_route_path =
+          case unquote(register_path) do
+            nil -> nil
+            {:unscoped, value} -> value
+            value -> value
+          end
+
         reset_path =
           case unquote(reset_path) do
             nil -> nil
             {:unscoped, value} -> value
             value -> Phoenix.Router.scoped_path(__MODULE__, value)
+          end
+
+        reset_route_path =
+          case unquote(reset_path) do
+            nil -> nil
+            {:unscoped, value} -> value
+            value -> value
           end
 
         auth_routes_prefix =
@@ -396,11 +410,11 @@ defmodule AshAuthentication.Phoenix.Router do
           live(unquote(path), unquote(live_view), :sign_in, as: unquote(as))
 
           if reset_path do
-            live(reset_path, unquote(live_view), :reset, as: :"#{unquote(as)}_reset")
+            live(reset_route_path, unquote(live_view), :reset, as: :"#{unquote(as)}_reset")
           end
 
           if register_path do
-            live(register_path, unquote(live_view), :register, as: :"#{unquote(as)}_register")
+            live(register_route_path, unquote(live_view), :register, as: :"#{unquote(as)}_register")
           end
         end
       end

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -31,10 +31,9 @@ defmodule AshAuthentication.Phoenix.RouterTest do
   end
 
   test "sign_in_routes respects the inherited router scope" do
-    route =
-      AshAuthentication.Phoenix.Test.Router
-      |> Phoenix.Router.routes()
-      |> Enum.find(&(&1.path == "/nested/sign-in"))
+    routes = Phoenix.Router.routes(AshAuthentication.Phoenix.Test.Router)
+
+    route = Enum.find(routes, &(&1.path == "/nested/sign-in"))
 
     {_, _, _, %{extra: %{session: session}}} = route.metadata.phoenix_live_view
 
@@ -52,6 +51,12 @@ defmodule AshAuthentication.Phoenix.RouterTest do
                   "resources" => nil
                 }
               ]}
+
+    assert Enum.find(routes, &(&1.path == "/nested/reset")),
+           "reset route should be at /nested/reset, not /nested/nested/reset"
+
+    assert Enum.find(routes, &(&1.path == "/nested/register")),
+           "register route should be at /nested/register, not /nested/nested/register"
   end
 
   test "sign_in_routes respects unscoped" do


### PR DESCRIPTION
## Summary

- Fixes double-nesting of `reset_path` and `register_path` routes when `sign_in_route` is used inside a Phoenix router `scope`
- The sign-in route was unaffected because it used the raw path option in the `live/4` call, but `reset_path`/`register_path` were passed through `Phoenix.Router.scoped_path/2` (adds scope prefix) and then used in `live/4` (adds scope prefix again)
- Adds separate `*_route_path` variables holding the raw paths for `live/4` route definitions, while keeping the scoped paths in session data for link generation

## Test plan

- [x] Added assertions to the existing `sign_in_routes respects the inherited router scope` test verifying that `/nested/reset` and `/nested/register` routes exist at the correct paths
- [x] Full test suite passes (131 tests, 0 failures)

Fixes team-alembic/ash_authentication#1151