### PR TITLE
fix: LiveView 1.2 compatibility

### DIFF
--- a/lib/ash_authentication_phoenix/components/banner.ex
+++ b/lib/ash_authentication_phoenix/components/banner.ex
@@ -60,6 +60,7 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
     <div class={override_for(@overrides, :root_class)}>
       <%= case {override_for(@overrides, :href_url), @image_url} do %>
         <% {_, nil} -> %>
+          {""}
         <% {nil, img} -> %>
           <img class={override_for(@overrides, :image_class)} src={img} />
         <% {hrf, img} -> %>
@@ -69,6 +70,7 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
       <% end %>
       <%= case {override_for(@overrides, :href_url), @dark_image_url} do %>
         <% {_, nil} -> %>
+          {""}
         <% {nil, img} -> %>
           <img class={override_for(@overrides, :dark_image_class)} src={img} />
         <% {hrf, img} -> %>
@@ -78,6 +80,7 @@ defmodule AshAuthentication.Phoenix.Components.Banner do
       <% end %>
       <%= case  {override_for(@overrides, :href_url), override_for(@overrides, :text)} do %>
         <% {_, nil} -> %>
+          {""}
         <% {nil, txt} -> %>
           <div class={override_for(@overrides, :text_class)}>
             {_gettext(txt)}

--- a/lib/ash_authentication_phoenix/components/password.ex
+++ b/lib/ash_authentication_phoenix/components/password.ex
@@ -205,6 +205,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
                 {render_slot(@sign_in_extra, form)}
               </div>
             <% true -> %>
+              {""}
           <% end %>
 
           <div class={override_for(@overrides, :interstitial_class)}>
@@ -264,6 +265,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
                   {render_slot(@register_extra, form)}
                 </div>
               <% true -> %>
+                {""}
             <% end %>
 
             <div class={override_for(@overrides, :interstitial_class)}>
@@ -320,6 +322,7 @@ defmodule AshAuthentication.Phoenix.Components.Password do
                   {render_slot(@reset_extra, form)}
                 </div>
               <% true -> %>
+                {""}
             <% end %>
 
             <div class={override_for(@overrides, :interstitial_class)}>

--- a/lib/ash_authentication_phoenix/components/totp.ex
+++ b/lib/ash_authentication_phoenix/components/totp.ex
@@ -142,12 +142,10 @@ defmodule AshAuthentication.Phoenix.Components.Totp do
             context={@context}
             gettext_fn={@gettext_fn}
           >
-            <%= cond do %>
-              <% @sign_in_extra != [] -> %>
-                <div class={override_for(@overrides, :slot_class)}>
-                  {render_slot(@sign_in_extra, form)}
-                </div>
-              <% true -> %>
+            <%= if @sign_in_extra != [] do %>
+              <div class={override_for(@overrides, :slot_class)}>
+                {render_slot(@sign_in_extra, form)}
+              </div>
             <% end %>
 
             <div class={override_for(@overrides, :interstitial_class)}>
@@ -179,12 +177,10 @@ defmodule AshAuthentication.Phoenix.Components.Totp do
             context={@context}
             gettext_fn={@gettext_fn}
           >
-            <%= cond do %>
-              <% @setup_extra != [] -> %>
-                <div class={override_for(@overrides, :slot_class)}>
-                  {render_slot(@setup_extra, form)}
-                </div>
-              <% true -> %>
+            <%= if @setup_extra != [] do %>
+              <div class={override_for(@overrides, :slot_class)}>
+                {render_slot(@setup_extra, form)}
+              </div>
             <% end %>
 
             <div class={override_for(@overrides, :interstitial_class)}>


### PR DESCRIPTION
LiveView `1.2.0-rc.0` has a stricter EEx compiler that forbids `cond` fallbacks with no body. In the case where a single `if` was appropriate, I switched to that, otherwise I used an empty string fallback. These changes are backwards compatible, so it works in all versions.

The rc also adds emits more warnings such as the forms using `phx-change` without an ID, but I didn't fix those in this commit as there are nuances better handled by those more familiar with the architecture than I.