### PR TITLE
improvement: handle `ConfirmationRequired` in the generated auth controller

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -371,6 +371,15 @@ if Code.ensure_loaded?(Igniter) do
                 You can confirm your account using the link we sent to you, or by resetting your password.
                 \"\"\"
 
+              {_,
+              %AshAuthentication.Errors.AuthenticationFailed{
+                caused_by: %AshAuthentication.Errors.ConfirmationRequired{}
+              }} ->
+                \"\"\"
+                An account with this email already exists. We've sent a link to that
+                address - confirm it to finish linking this provider to your account.
+                \"\"\"
+
               _ ->
                 "Incorrect email or password"
             end

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -141,6 +141,15 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
               You can confirm your account using the link we sent to you, or by resetting your password.
               \"\"\"
 
+            {_,
+             %AshAuthentication.Errors.AuthenticationFailed{
+               caused_by: %AshAuthentication.Errors.ConfirmationRequired{}
+             }} ->
+              \"\"\"
+              An account with this email already exists. We've sent a link to that
+              address - confirm it to finish linking this provider to your account.
+              \"\"\"
+
             _ ->
               "Incorrect email or password"
           end


### PR DESCRIPTION
Backport of the OAuth2 confirm-to-link UX for the 4.x line. When an OAuth2/OIDC sign-in hits `on_untrusted_email_match :confirm`, the generated `AuthController.failure/3` now matches the `ConfirmationRequired` reason and flashes "check your email to finish linking this provider" instead of a generic error. (The confirmation email copy is generated by ash_authentication 4.x.)