### PR TITLE
improvement: consolidate on_mount/4 clauses to avoid Elixir 1.19 type-checker slowdown

### DIFF
--- a/lib/ash_authentication_phoenix/live_session.ex
+++ b/lib/ash_authentication_phoenix/live_session.ex
@@ -150,12 +150,21 @@ defmodule AshAuthentication.Phoenix.LiveSession do
           Socket.t()
         ) ::
           {:cont | :halt, Socket.t()}
-  def on_mount({:set_otp_app, otp_app}, _params, _, socket) do
-    {:cont, assign(socket, :otp_app, otp_app)}
+  def on_mount(action, _params, session, socket) do
+    case action do
+      {:set_otp_app, otp_app} ->
+        {:cont, assign(socket, :otp_app, otp_app)}
+
+      :default ->
+        mount_default(session, socket)
+
+      _ ->
+        {:cont, socket}
+    end
   end
 
   # sobelow_skip ["DOS.StringToAtom"]
-  def on_mount(:default, _params, session, socket) do
+  defp mount_default(session, socket) do
     tenant = socket.assigns[:current_tenant] || session["tenant"]
 
     socket =
@@ -209,8 +218,6 @@ defmodule AshAuthentication.Phoenix.LiveSession do
     end)
     |> then(&{:cont, &1})
   end
-
-  def on_mount(_, _params, _session, socket), do: {:cont, socket}
 
   @doc """
   Supplements the session with any `current_X` assigns which are authenticated

--- a/lib/ash_authentication_phoenix/router/on_live_view_mount.ex
+++ b/lib/ash_authentication_phoenix/router/on_live_view_mount.ex
@@ -7,9 +7,13 @@ defmodule AshAuthentication.Phoenix.Router.OnLiveViewMount do
   import Phoenix.Component
 
   @doc false
-  def on_mount(:default, _params, %{"otp_app" => otp_app}, socket) when not is_nil(otp_app) do
-    {:cont, assign(socket, :otp_app, otp_app)}
-  end
+  def on_mount(action, _params, session, socket) do
+    case {action, session} do
+      {:default, %{"otp_app" => otp_app}} when not is_nil(otp_app) ->
+        {:cont, assign(socket, :otp_app, otp_app)}
 
-  def on_mount(_, _params, _session, socket), do: {:cont, socket}
+      _ ->
+        {:cont, socket}
+    end
+  end
 end

--- a/lib/mix/tasks/ash_authentication_phoenix.setup.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.setup.ex
@@ -280,34 +280,39 @@ if Code.ensure_loaded?(Igniter) do
         import Phoenix.Component
         use #{inspect(web_module)}, :verified_routes
 
+        # Clauses are dispatched via a single `on_mount/4` head with an
+        # internal `case` rather than separate function heads. Multiple
+        # `on_mount/4` heads trigger pathological compile-time slowdowns in
+        # Elixir 1.19+'s type checker during router verification.
+        #
         # This is used for nested liveviews to fetch the current user.
         # To use, place the following at the top of that liveview:
         # on_mount {#{inspect(live_user_auth)}, :current_user}
-        def on_mount(:current_user, _params, session, socket) do
-          {:cont, AshAuthentication.Phoenix.LiveSession.assign_new_resources(socket, session)}
-        end
+        def on_mount(action, _params, session, socket) do
+          case action do
+            :current_user ->
+              {:cont, AshAuthentication.Phoenix.LiveSession.assign_new_resources(socket, session)}
 
-        def on_mount(:live_user_optional, _params, _session, socket) do
-          if socket.assigns[:current_user] do
-            {:cont, socket}
-          else
-            {:cont, assign(socket, :current_user, nil)}
-          end
-        end
+            :live_user_optional ->
+              if socket.assigns[:current_user] do
+                {:cont, socket}
+              else
+                {:cont, assign(socket, :current_user, nil)}
+              end
 
-        def on_mount(:live_user_required, _params, _session, socket) do
-          if socket.assigns[:current_user] do
-            {:cont, socket}
-          else
-            {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
-          end
-        end
+            :live_user_required ->
+              if socket.assigns[:current_user] do
+                {:cont, socket}
+              else
+                {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+              end
 
-        def on_mount(:live_no_user, _params, _session, socket) do
-          if socket.assigns[:current_user] do
-            {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
-          else
-            {:cont, assign(socket, :current_user, nil)}
+            :live_no_user ->
+              if socket.assigns[:current_user] do
+                {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+              else
+                {:cont, assign(socket, :current_user, nil)}
+              end
           end
         end
         """

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -190,34 +190,39 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
       import Phoenix.Component
       use TestWeb, :verified_routes
 
+      # Clauses are dispatched via a single `on_mount/4` head with an
+      # internal `case` rather than separate function heads. Multiple
+      # `on_mount/4` heads trigger pathological compile-time slowdowns in
+      # Elixir 1.19+'s type checker during router verification.
+      #
       # This is used for nested liveviews to fetch the current user.
       # To use, place the following at the top of that liveview:
       # on_mount {TestWeb.LiveUserAuth, :current_user}
-      def on_mount(:current_user, _params, session, socket) do
-        {:cont, AshAuthentication.Phoenix.LiveSession.assign_new_resources(socket, session)}
-      end
+      def on_mount(action, _params, session, socket) do
+        case action do
+          :current_user ->
+            {:cont, AshAuthentication.Phoenix.LiveSession.assign_new_resources(socket, session)}
 
-      def on_mount(:live_user_optional, _params, _session, socket) do
-        if socket.assigns[:current_user] do
-          {:cont, socket}
-        else
-          {:cont, assign(socket, :current_user, nil)}
-        end
-      end
+          :live_user_optional ->
+            if socket.assigns[:current_user] do
+              {:cont, socket}
+            else
+              {:cont, assign(socket, :current_user, nil)}
+            end
 
-      def on_mount(:live_user_required, _params, _session, socket) do
-        if socket.assigns[:current_user] do
-          {:cont, socket}
-        else
-          {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
-        end
-      end
+          :live_user_required ->
+            if socket.assigns[:current_user] do
+              {:cont, socket}
+            else
+              {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+            end
 
-      def on_mount(:live_no_user, _params, _session, socket) do
-        if socket.assigns[:current_user] do
-          {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
-        else
-          {:cont, assign(socket, :current_user, nil)}
+          :live_no_user ->
+            if socket.assigns[:current_user] do
+              {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/")}
+            else
+              {:cont, assign(socket, :current_user, nil)}
+            end
         end
       end
     end


### PR DESCRIPTION
Addresses #714.

## Background

Elixir 1.19+'s parallel type checker has pathological exponential compile-time behaviour (`tuple_empty?`/`bdd_difference`) during router verification when a module defines many `on_mount/4` function-head clauses. With the installer-generated `LiveUserAuth` (4 clauses), router verification can take >10s on every LiveView change. The root cause is upstream (see the Elixir tickets linked in #714); this reduces our contribution to it.

## Change

Collapse the multiple `on_mount/4` heads into a **single head dispatching via an internal `case`** in:

- the installer-generated `LiveUserAuth` (`setup.ex`) — the main contributor, 4 clauses → 1
- `AshAuthentication.Phoenix.LiveSession` — 3 clauses → 1 (the `:default` body extracted to a private `mount_default/2` to keep nesting depth within credo limits)
- `AshAuthentication.Phoenix.Router.OnLiveViewMount` — 2 clauses → 1

Behaviour is unchanged; this is purely a clause-shape change to sidestep the type-checker blowup.

## Notes

- Existing apps won't pick up the installer change automatically — the workaround (same consolidation in their own `LiveUserAuth`) is documented in #714.
- Verified locally: `mix compile --warnings-as-errors`, `mix format --check`, `mix credo --strict`, full test suite (169 tests, 0 failures); installer test updated to expect the consolidated output.