### PR TITLE
improvement: add `id` to form components to enable LiveView form recovery

### DIFF
--- a/lib/ash_authentication_phoenix/components/confirm/form.ex
+++ b/lib/ash_authentication_phoenix/components/confirm/form.ex
@@ -108,6 +108,7 @@ defmodule AshAuthentication.Phoenix.Components.Confirm.Form do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-submit="submit"
         phx-trigger-action={@trigger_action}
         phx-target={@myself}

--- a/lib/ash_authentication_phoenix/components/magic_link.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link.ex
@@ -92,6 +92,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-change="change"
         phx-submit="submit"
         phx-trigger-action={@trigger_action}

--- a/lib/ash_authentication_phoenix/components/magic_link/form.ex
+++ b/lib/ash_authentication_phoenix/components/magic_link/form.ex
@@ -103,6 +103,7 @@ defmodule AshAuthentication.Phoenix.Components.MagicLink.Form do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-submit="submit"
         phx-trigger-action={@trigger_action}
         phx-target={@myself}

--- a/lib/ash_authentication_phoenix/components/password/register_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/register_form.ex
@@ -130,6 +130,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.RegisterForm do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-change="change"
         phx-submit="submit"
         phx-trigger-action={@trigger_action}

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -95,6 +95,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-submit="submit"
         phx-change="change"
         phx-target={@myself}

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -114,6 +114,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
       <.form
         :let={form}
         for={@form}
+        id={@form.id}
         phx-change="change"
         phx-submit="submit"
         phx-trigger-action={@trigger_action}

--- a/lib/ash_authentication_phoenix/components/webauthn/authentication_form.ex
+++ b/lib/ash_authentication_phoenix/components/webauthn/authentication_form.ex
@@ -70,6 +70,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.AuthenticationForm do
     ~H"""
     <div class={override_for(@overrides, :root_class)} id={@id} phx-hook="WebAuthnAuthenticationHook">
       <form
+        id={"#{@id}-form"}
         phx-change="update-identity"
         phx-submit="authenticate"
         phx-target={@myself}
@@ -99,6 +100,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.AuthenticationForm do
 
       <.form
         for={%{}}
+        id={"#{@id}-token-form"}
         as={:user}
         action={
           auth_path(

--- a/lib/ash_authentication_phoenix/components/webauthn/registration_form.ex
+++ b/lib/ash_authentication_phoenix/components/webauthn/registration_form.ex
@@ -62,6 +62,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.RegistrationForm do
     ~H"""
     <div class={override_for(@overrides, :root_class)} id={@id} phx-hook="WebAuthnRegistrationHook">
       <form
+        id={"#{@id}-form"}
         phx-change="update-identity"
         phx-submit="register"
         phx-target={@myself}
@@ -89,6 +90,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.RegistrationForm do
 
       <.form
         for={%{}}
+        id={"#{@id}-token-form"}
         as={:user}
         action={
           auth_path(

--- a/lib/ash_authentication_phoenix/components/webauthn/verify_2fa_form.ex
+++ b/lib/ash_authentication_phoenix/components/webauthn/verify_2fa_form.ex
@@ -122,6 +122,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.Verify2faForm do
           </a>
         <% _ -> %>
           <form
+            id={"#{@id}-form"}
             phx-submit="start-verify"
             phx-target={@myself}
             class={override_for(@overrides, :form_class)}
@@ -142,6 +143,7 @@ defmodule AshAuthentication.Phoenix.Components.WebAuthn.Verify2faForm do
           <%= if @subject_name_slug && @strategy && @auth_routes_prefix do %>
             <.form
               for={%{}}
+              id={"#{@id}-token-form"}
               as={:user}
               action={
                 auth_path(


### PR DESCRIPTION
Fixes #749.

LiveView emits a `missing_form_id` warning (and cannot perform form recovery on crash/disconnect) for any form with `phx-change`/`phx-submit` that lacks an `id`. Several of the generated auth forms were missing one.

## Changes

Added `id` to the form components that were missing it, matching the existing pattern in `sign_in_form`/`otp` components:

- `password/register_form`, `password/reset_form`, `magic_link`, `magic_link/form`, `reset/form`, `confirm/form` — `id={@form.id}`
- `webauthn/authentication_form`, `webauthn/registration_form`, `webauthn/verify_2fa_form` — `id={"#{@id}-form"}` on the raw interactive form and `id={"#{@id}-token-form"}` on the hidden trigger-action form

## Verification

`mix test` — 169 tests, 0 failures, and no `missing_form_id` warnings remain.