### PR TITLE
improvement: allow overriding the reset password submit label (#665)

### DIFF
--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -278,6 +278,8 @@ Renders a password-reset form.
 
 Generates a default password reset form.
 
+  * `:button_text` - Text for the submit button.
+
   * `:disable_button_text` - Text for the submit button when the request is happening.
 
   * `:form_class` - CSS class for the `form` element.
@@ -293,7 +295,7 @@ Generates a default password reset form.
 
 Generates a default password reset form.
 
-  * `:button_text` - Tex for the submit button.
+  * `:button_text` - Text for the submit button.
 
   * `:disable_button_text` - Text for the submit button when the request is happening.
 

--- a/lib/ash_authentication_phoenix/components/password/reset_form.ex
+++ b/lib/ash_authentication_phoenix/components/password/reset_form.ex
@@ -8,7 +8,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.ResetForm do
     label_class: "CSS class for the `h2` element.",
     form_class: "CSS class for the `form` element.",
     slot_class: "CSS class for the `div` surrounding the slot.",
-    button_text: "Tex for the submit button.",
+    button_text: "Text for the submit button.",
     disable_button_text: "Text for the submit button when the request is happening.",
     reset_flash_text:
       "Text for the flash message when a request is received.  Set to `nil` to disable."

--- a/lib/ash_authentication_phoenix/components/reset/form.ex
+++ b/lib/ash_authentication_phoenix/components/reset/form.ex
@@ -8,6 +8,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
     label_class: "CSS class for the `h2` element.",
     form_class: "CSS class for the `form` element.",
     spacer_class: "CSS classes for space between the password input and submit elements.",
+    button_text: "Text for the submit button.",
     disable_button_text: "Text for the submit button when the request is happening."
 
   @moduledoc """
@@ -161,6 +162,7 @@ defmodule AshAuthentication.Phoenix.Components.Reset.Form do
           strategy={@strategy}
           form={form}
           action={:reset}
+          label={override_for(@overrides, :button_text)}
           disable_text={_gettext(override_for(@overrides, :disable_button_text))}
           overrides={@overrides}
           gettext_fn={@gettext_fn}

--- a/test/password_reset_test.exs
+++ b/test/password_reset_test.exs
@@ -31,7 +31,14 @@ defmodule AshAuthentication.Phoenix.PasswordResetTest do
   test "reset_route routes liveview renders the password reset page", %{conn: conn} do
     conn = get(conn, "/password-reset/my_token_213")
     assert {:ok, _view, html} = live(conn)
-    assert html =~ "Password reset"
+    assert html =~ "Change password"
+  end
+
+  test "reset_route honours an overridden submit button text", %{conn: conn} do
+    conn = get(conn, "/password-reset-custom-button/my_token_213")
+    assert {:ok, _view, html} = live(conn)
+    assert html =~ "Set new password"
+    refute html =~ "Change password"
   end
 
   test "reset_route routes liveview honours external gettext_fn", %{conn: conn} do

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -170,6 +170,14 @@ defmodule AshAuthentication.Phoenix.Test.Router do
                 auth_routes_prefix: "/auth",
                 gettext_backend: {AshAuthentication.Phoenix.Test.Gettext, "test"},
                 as: :gettext_backend
+
+    reset_route path: "/password-reset-custom-button",
+                auth_routes_prefix: "/auth",
+                overrides: [
+                  AshAuthentication.Phoenix.Test.ResetButtonOverride,
+                  AshAuthentication.Phoenix.Overrides.Default
+                ],
+                as: :custom_button
   end
 
   scope "/nested", AshAuthentication.Phoenix.Test do

--- a/test/support/reset_button_override.ex
+++ b/test/support/reset_button_override.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.Phoenix.Test.ResetButtonOverride do
+  @moduledoc false
+  use AshAuthentication.Phoenix.Overrides
+  alias AshAuthentication.Phoenix.Components
+
+  override Components.Reset.Form do
+    set :button_text, "Set new password"
+  end
+end


### PR DESCRIPTION
Closes #665.

## Problem

The submit button on the password reset form at `/password-reset/:token` was locked to the humanised action name (e.g. "Reset password with token") with no way to override it. The `AuthOverrides` system had no effect on it.

## Cause

`AshAuthentication.Phoenix.Components.Reset.Form` never wired up a `button_text` override:

- It didn't declare `button_text` in its `Overridable` list.
- It didn't pass a `label` to `Input.submit`, so the button fell back to the humanised action name.

Curiously, the Default overrides already set `button_text` to `"Change password"` for this component — but it was dead, since the component never consumed it.

## Fix

Two lines in `Reset.Form`, mirroring how `Password.ResetForm` (the *request* reset form) already works:

- Declare the `button_text` override.
- Pass `label={override_for(@overrides, :button_text)}` to `Input.submit`.

## Behaviour change

Because the Default override already specified `"Change password"`, the default button label now reflects that instead of the humanised action name. Anyone relying on the default text will see "Change password" rather than "Reset password with token" / "Password reset". Overriding `button_text` in an `AuthOverrides` module now works as expected.

## Also

- Fixed a `"Tex"` → `"Text"` typo in the `Password.ResetForm` docstring.
- Updated `documentation/tutorials/ui-overrides.md` to list `:button_text` under `Reset.Form`.

## Tests

- Added a `reset_route` wired to a test override module setting a custom `button_text`, with a test asserting it renders.
- Updated the existing reset-page test to assert the new default.

All 170 tests pass; `mix check` is green except `reuse`, which fails for an unrelated local-tooling reason (missing charset-detection module in the `reuse` install).
