### PR TITLE
improvement: add optional password visibility toggle (#657)

### DIFF
--- a/dev/dev_web/auth_overrides.ex
+++ b/dev/dev_web/auth_overrides.ex
@@ -10,4 +10,8 @@ defmodule DevWeb.AuthOverrides do
   override Components.Banner do
     set :image_url, "https://media.giphy.com/media/g7GKcSzwQfugw/giphy.gif"
   end
+
+  override Components.Password.Input do
+    set :password_toggle_visibility, true
+  end
 end

--- a/documentation/tutorials/ui-overrides.md
+++ b/documentation/tutorials/ui-overrides.md
@@ -338,7 +338,19 @@ authentication.
 
   * `:password_confirmation_input_label` - Label for password confirmation field.
 
+  * `:password_field_wrapper_class` - CSS class for the `div` wrapping the password `input` and its visibility toggle button.
+
+  * `:password_hide_label` - Label for the password visibility toggle button when the password is shown.
+
   * `:password_input_label` - Label for password field.
+
+  * `:password_show_label` - Label for the password visibility toggle button when the password is hidden.
+
+  * `:password_toggle_class` - CSS class for the password visibility toggle `button`.
+
+  * `:password_toggle_icon_class` - CSS class for the `svg` icons in the password visibility toggle.
+
+  * `:password_toggle_visibility` - Whether to show a button that toggles the visibility of password fields. Defaults to `false`.
 
   * `:remember_me_class` - CSS class for the `div` element surrounding the remember me field.
 

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -20,7 +20,16 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     remember_me_class: "CSS class for the `div` element surrounding the remember me field.",
     remember_me_input_label: "Label for remember me field.",
     checkbox_class: "CSS class for the `input` element of the remember me field.",
-    checkbox_label_class: "CSS class for the `label` element of the remember me field."
+    checkbox_label_class: "CSS class for the `label` element of the remember me field.",
+    password_toggle_visibility:
+      "Whether to show a button that toggles the visibility of password fields. Defaults to `false`.",
+    password_field_wrapper_class:
+      "CSS class for the `div` wrapping the password `input` and its visibility toggle button.",
+    password_toggle_class: "CSS class for the password visibility toggle `button`.",
+    password_show_label:
+      "Label for the password visibility toggle button when the password is hidden.",
+    password_hide_label:
+      "Label for the password visibility toggle button when the password is shown."
 
   @moduledoc """
   Function components for dealing with form input during password
@@ -39,7 +48,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
   use AshAuthentication.Phoenix.Web, :component
   alias AshAuthentication.Strategy
   alias AshPhoenix.Form
-  alias Phoenix.LiveView.{Rendered, Socket}
+  alias Phoenix.LiveView.{JS, Rendered, Socket}
   import Phoenix.HTML.Form
   import PhoenixHTMLHelpers.Form
 
@@ -152,11 +161,13 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       {label(@form, @password_field, _gettext(override_for(@overrides, :password_input_label)),
         class: override_for(@overrides, :label_class)
       )}
-      {password_input(@form, @password_field,
-        class: @input_class,
-        value: input_value(@form, @password_field),
-        phx_debounce: override_for(@overrides, :input_debounce)
-      )}
+      <.password_input_with_toggle
+        form={@form}
+        field={@password_field}
+        input_class={@input_class}
+        overrides={@overrides}
+        gettext_fn={@gettext_fn}
+      />
       <.error form={@form} field={@password_field} overrides={@overrides} />
     </div>
     """
@@ -206,11 +217,13 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
         _gettext(override_for(@overrides, :password_confirmation_input_label)),
         class: override_for(@overrides, :label_class)
       )}
-      {password_input(@form, @password_confirmation_field,
-        class: @input_class,
-        value: input_value(@form, @password_confirmation_field),
-        phx_debounce: override_for(@overrides, :input_debounce)
-      )}
+      <.password_input_with_toggle
+        form={@form}
+        field={@password_confirmation_field}
+        input_class={@input_class}
+        overrides={@overrides}
+        gettext_fn={@gettext_fn}
+      />
       <.error form={@form} field={@password_confirmation_field} overrides={@overrides} />
     </div>
     """
@@ -378,6 +391,48 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
       </ul>
     <% end %>
     """
+  end
+
+  defp password_input_with_toggle(assigns) do
+    assigns = assign(assigns, :input_id, input_id(assigns.form, assigns.field))
+
+    ~H"""
+    <%= if override_for(@overrides, :password_toggle_visibility) do %>
+      <div class={override_for(@overrides, :password_field_wrapper_class)}>
+        {password_input(@form, @field,
+          id: @input_id,
+          class: @input_class,
+          value: input_value(@form, @field),
+          phx_debounce: override_for(@overrides, :input_debounce)
+        )}
+        <button
+          type="button"
+          class={override_for(@overrides, :password_toggle_class)}
+          phx-click={toggle_password_visibility(@input_id)}
+        >
+          <span id={"#{@input_id}-show-label"}>
+            {_gettext(override_for(@overrides, :password_show_label))}
+          </span>
+          <span id={"#{@input_id}-hide-label"} style="display: none;">
+            {_gettext(override_for(@overrides, :password_hide_label))}
+          </span>
+        </button>
+      </div>
+    <% else %>
+      {password_input(@form, @field,
+        class: @input_class,
+        value: input_value(@form, @field),
+        phx_debounce: override_for(@overrides, :input_debounce)
+      )}
+    <% end %>
+    """
+  end
+
+  defp toggle_password_visibility(input_id) do
+    %JS{}
+    |> JS.toggle_attribute({"type", "text", "password"}, to: "##{input_id}")
+    |> JS.toggle(to: "##{input_id}-show-label")
+    |> JS.toggle(to: "##{input_id}-hide-label")
   end
 
   defp has_error?(form, field) do

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -411,10 +411,47 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
           phx-click={toggle_password_visibility(@input_id)}
         >
           <span id={"#{@input_id}-show-label"}>
-            {_gettext(override_for(@overrides, :password_show_label))}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+              focusable="false"
+              class="h-5 w-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+              />
+            </svg>
+            <span class="sr-only">{_gettext(override_for(@overrides, :password_show_label))}</span>
           </span>
           <span id={"#{@input_id}-hide-label"} style="display: none;">
-            {_gettext(override_for(@overrides, :password_hide_label))}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+              focusable="false"
+              class="h-5 w-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"
+              />
+            </svg>
+            <span class="sr-only">{_gettext(override_for(@overrides, :password_hide_label))}</span>
           </span>
         </button>
       </div>

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -167,6 +167,11 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
         input_class={@input_class}
         overrides={@overrides}
         gettext_fn={@gettext_fn}
+        toggle_button={true}
+        also_toggle_id={
+          if @strategy.confirmation_required?,
+            do: input_id(@form, @strategy.password_confirmation_field)
+        }
       />
       <.error form={@form} field={@password_field} overrides={@overrides} />
     </div>
@@ -223,6 +228,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
         input_class={@input_class}
         overrides={@overrides}
         gettext_fn={@gettext_fn}
+        toggle_button={false}
       />
       <.error form={@form} field={@password_confirmation_field} overrides={@overrides} />
     </div>
@@ -394,7 +400,11 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
   end
 
   defp password_input_with_toggle(assigns) do
-    assigns = assign(assigns, :input_id, input_id(assigns.form, assigns.field))
+    assigns =
+      assigns
+      |> assign(:input_id, input_id(assigns.form, assigns.field))
+      |> assign_new(:toggle_button, fn -> true end)
+      |> assign_new(:also_toggle_id, fn -> nil end)
 
     ~H"""
     <%= if override_for(@overrides, :password_toggle_visibility) do %>
@@ -406,9 +416,10 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
           phx_debounce: override_for(@overrides, :input_debounce)
         )}
         <button
+          :if={@toggle_button}
           type="button"
           class={override_for(@overrides, :password_toggle_class)}
-          phx-click={toggle_password_visibility(@input_id)}
+          phx-click={toggle_password_visibility(@input_id, @also_toggle_id)}
         >
           <span id={"#{@input_id}-show-label"}>
             <svg
@@ -465,12 +476,18 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     """
   end
 
-  defp toggle_password_visibility(input_id) do
+  defp toggle_password_visibility(input_id, also_toggle_id) do
     %JS{}
     |> JS.toggle_attribute({"type", "text", "password"}, to: "##{input_id}")
+    |> maybe_toggle_attribute(also_toggle_id)
     |> JS.toggle(to: "##{input_id}-show-label")
     |> JS.toggle(to: "##{input_id}-hide-label")
   end
+
+  defp maybe_toggle_attribute(js, nil), do: js
+
+  defp maybe_toggle_attribute(js, input_id),
+    do: JS.toggle_attribute(js, {"type", "text", "password"}, to: "##{input_id}")
 
   defp has_error?(form, field) do
     form

--- a/lib/ash_authentication_phoenix/components/password/input.ex
+++ b/lib/ash_authentication_phoenix/components/password/input.ex
@@ -26,6 +26,8 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
     password_field_wrapper_class:
       "CSS class for the `div` wrapping the password `input` and its visibility toggle button.",
     password_toggle_class: "CSS class for the password visibility toggle `button`.",
+    password_toggle_icon_class:
+      "CSS class for the `svg` icons in the password visibility toggle.",
     password_show_label:
       "Label for the password visibility toggle button when the password is hidden.",
     password_hide_label:
@@ -430,7 +432,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
               stroke="currentColor"
               aria-hidden="true"
               focusable="false"
-              class="h-5 w-5"
+              class={override_for(@overrides, :password_toggle_icon_class)}
             >
               <path
                 stroke-linecap="round"
@@ -454,7 +456,7 @@ defmodule AshAuthentication.Phoenix.Components.Password.Input do
               stroke="currentColor"
               aria-hidden="true"
               focusable="false"
-              class="h-5 w-5"
+              class={override_for(@overrides, :password_toggle_icon_class)}
             >
               <path
                 stroke-linecap="round"

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -287,6 +287,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :password_toggle_class,
         "btn btn-ghost btn-sm btn-square absolute right-1 top-1/2 -translate-y-1/2"
 
+    set :password_toggle_icon_class, "h-5 w-5"
     set :password_show_label, "Show password"
     set :password_hide_label, "Hide password"
   end

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -285,7 +285,7 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :password_field_wrapper_class, "relative"
 
     set :password_toggle_class,
-        "btn btn-ghost btn-sm absolute inset-y-0 right-0 flex items-center"
+        "btn btn-ghost btn-sm absolute right-1 top-1/2 -translate-y-1/2"
 
     set :password_show_label, "Show"
     set :password_hide_label, "Hide"

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -281,6 +281,14 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :remember_me_input_label, "Remember me"
     set :checkbox_class, "dark:text-white mr-2"
     set :checkbox_label_class, "text-sm font-medium text-gray-700 dark:text-white"
+    set :password_toggle_visibility, false
+    set :password_field_wrapper_class, "relative"
+
+    set :password_toggle_class,
+        "btn btn-ghost btn-sm absolute inset-y-0 right-0 flex items-center"
+
+    set :password_show_label, "Show"
+    set :password_hide_label, "Hide"
   end
 
   override Components.OAuth2 do

--- a/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
+++ b/lib/ash_authentication_phoenix/overrides/daisy_ui.ex
@@ -285,10 +285,10 @@ defmodule AshAuthentication.Phoenix.Overrides.DaisyUI do
     set :password_field_wrapper_class, "relative"
 
     set :password_toggle_class,
-        "btn btn-ghost btn-sm absolute right-1 top-1/2 -translate-y-1/2"
+        "btn btn-ghost btn-sm btn-square absolute right-1 top-1/2 -translate-y-1/2"
 
-    set :password_show_label, "Show"
-    set :password_hide_label, "Hide"
+    set :password_show_label, "Show password"
+    set :password_hide_label, "Hide password"
   end
 
   override Components.OAuth2 do

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -340,8 +340,8 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     text-blue-500 hover:text-blue-600 focus:outline-none dark:text-blue-400
     """
 
-    set :password_show_label, "Show"
-    set :password_hide_label, "Hide"
+    set :password_show_label, "Show password"
+    set :password_hide_label, "Hide password"
   end
 
   override Components.OAuth2 do

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -340,6 +340,7 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     text-blue-500 hover:text-blue-600 focus:outline-none dark:text-blue-400
     """
 
+    set :password_toggle_icon_class, "h-5 w-5"
     set :password_show_label, "Show password"
     set :password_hide_label, "Hide password"
   end

--- a/lib/ash_authentication_phoenix/overrides/default.ex
+++ b/lib/ash_authentication_phoenix/overrides/default.ex
@@ -332,6 +332,16 @@ defmodule AshAuthentication.Phoenix.Overrides.Default do
     set :remember_me_input_label, "Remember me"
     set :checkbox_class, "dark:text-white mr-2"
     set :checkbox_label_class, "text-sm font-medium text-gray-700 dark:text-white"
+    set :password_toggle_visibility, false
+    set :password_field_wrapper_class, "relative"
+
+    set :password_toggle_class, """
+    absolute inset-y-0 right-0 flex items-center px-3 text-sm font-medium
+    text-blue-500 hover:text-blue-600 focus:outline-none dark:text-blue-400
+    """
+
+    set :password_show_label, "Show"
+    set :password_hide_label, "Hide"
   end
 
   override Components.OAuth2 do

--- a/test/sign_in_test.exs
+++ b/test/sign_in_test.exs
@@ -115,6 +115,17 @@ defmodule AshAuthentication.Phoenix.SignInTest do
     assert has_element?(view, "button span[id$=\"-hide-label\"] span.sr-only", "Hide password")
   end
 
+  test "register page shows a single toggle that controls both password fields", %{conn: conn} do
+    conn = get(conn, "/register-password-toggle")
+    assert {:ok, view, html} = live(conn)
+
+    assert has_element?(view, "button span[id$=\"-show-label\"]")
+
+    refute html =~ "password_confirmation-show-label"
+
+    assert html =~ "#user-password-register-with-password_password_confirmation"
+  end
+
   test "sign_in liveview honours filter_strategy override", %{conn: conn} do
     conn = get(conn, "/sign-in-filtered")
 

--- a/test/sign_in_test.exs
+++ b/test/sign_in_test.exs
@@ -98,6 +98,23 @@ defmodule AshAuthentication.Phoenix.SignInTest do
     assert html =~ "ever gonna"
   end
 
+  test "password visibility toggle is hidden by default", %{conn: conn} do
+    conn = get(conn, "/sign-in")
+    assert {:ok, _view, html} = live(conn)
+
+    refute html =~ "-show-label"
+  end
+
+  test "password visibility toggle is rendered when enabled via override", %{conn: conn} do
+    conn = get(conn, "/sign-in-password-toggle")
+    assert {:ok, view, html} = live(conn)
+
+    assert html =~ "-show-label"
+    assert html =~ "Show"
+    assert html =~ "Hide"
+    assert has_element?(view, "button[phx-click] span[id$=\"-show-label\"]")
+  end
+
   test "sign_in liveview honours filter_strategy override", %{conn: conn} do
     conn = get(conn, "/sign-in-filtered")
 

--- a/test/sign_in_test.exs
+++ b/test/sign_in_test.exs
@@ -110,9 +110,9 @@ defmodule AshAuthentication.Phoenix.SignInTest do
     assert {:ok, view, html} = live(conn)
 
     assert html =~ "-show-label"
-    assert html =~ "Show"
-    assert html =~ "Hide"
-    assert has_element?(view, "button[phx-click] span[id$=\"-show-label\"]")
+    assert has_element?(view, "button[phx-click] svg[aria-hidden=\"true\"]")
+    assert has_element?(view, "button span[id$=\"-show-label\"] span.sr-only", "Show password")
+    assert has_element?(view, "button span[id$=\"-hide-label\"] span.sr-only", "Hide password")
   end
 
   test "sign_in liveview honours filter_strategy override", %{conn: conn} do

--- a/test/support/password_toggle_override.ex
+++ b/test/support/password_toggle_override.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Alembic Pty Ltd
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshAuthentication.Phoenix.Test.PasswordToggleOverride do
+  @moduledoc false
+  use AshAuthentication.Phoenix.Overrides
+  alias AshAuthentication.Phoenix.Components
+
+  override Components.Password.Input do
+    set :password_toggle_visibility, true
+  end
+end

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -138,6 +138,14 @@ defmodule AshAuthentication.Phoenix.Test.Router do
                   overrides: [AshAuthentication.Phoenix.Test.FilterInviteOverride],
                   as: :filtered
 
+    sign_in_route path: "/sign-in-password-toggle",
+                  auth_routes_prefix: "/auth",
+                  overrides: [
+                    AshAuthentication.Phoenix.Test.PasswordToggleOverride,
+                    AshAuthentication.Phoenix.Overrides.Default
+                  ],
+                  as: :password_toggle
+
     # Custom LiveView for components testing
     sign_in_route path: "/custom_lv",
                   auth_routes_prefix: "/auth",

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -139,6 +139,7 @@ defmodule AshAuthentication.Phoenix.Test.Router do
                   as: :filtered
 
     sign_in_route path: "/sign-in-password-toggle",
+                  register_path: "/register-password-toggle",
                   auth_routes_prefix: "/auth",
                   overrides: [
                     AshAuthentication.Phoenix.Test.PasswordToggleOverride,


### PR DESCRIPTION
Closes #657.

Adds an opt-in show/hide toggle for password fields, configured through the existing override system. It is **disabled by default**, so existing behaviour is unchanged.

## Approach

- The toggle is a UI-only concern, so it lives in the `ash_authentication_phoenix` override system rather than the core `ash_authentication` strategy DSL.
- Purely client-side: a `type="button"` toggle flips the input's `type` between `password` and `text` using `Phoenix.LiveView.JS` (`toggle_attribute`), with no new JS assets or hooks.
- The button uses inline Heroicons v2 (eye / eye-slash) — no icon dependency, consistent with how the library already inlines SVGs.
- When password confirmation is enabled, a **single** toggle on the password field controls both inputs; the confirmation field renders no button of its own.

## Accessibility

- Each SVG is `aria-hidden="true"` / `focusable="false"`.
- Each state carries an `sr-only` text label ("Show password" / "Hide password"). Toggling hides the inactive state with `display: none`, so only the active label is in the accessibility tree — the button's accessible name updates as the state changes, with no static `aria-label` to conflict.

## New `Components.Password.Input` overrides

| Override | Default | Purpose |
|---|---|---|
| `password_toggle_visibility` | `false` | Enables the toggle button |
| `password_field_wrapper_class` | `"relative"` | Wrapper around input + button |
| `password_toggle_class` | themed | The toggle `button` |
| `password_show_label` | `"Show password"` | Screen-reader label when password is hidden |
| `password_hide_label` | `"Hide password"` | Screen-reader label when password is shown |

Defaults added to both the default and DaisyUI override modules.

## Usage

```elixir
defmodule MyAppWeb.AuthOverrides do
  use AshAuthentication.Phoenix.Overrides
  alias AshAuthentication.Phoenix.Components

  override Components.Password.Input do
    set :password_toggle_visibility, true
  end
end
```

## Tests

- Toggle absent by default.
- Toggle rendered (with icons and sr-only labels) when enabled via an override.
- On the register page, a single toggle controls both the password and confirmation inputs.

Full suite passes (172 tests, 0 failures), formatted.