### PR TITLE
improvement: avoid compile-time dependencies from route macro options

### DIFF
--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -707,6 +707,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro totp_2fa_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/totp-verify")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.TotpVerifyLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -962,6 +963,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro webauthn_2fa_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/webauthn-verify")
 
     {live_view, opts} =

--- a/lib/ash_authentication_phoenix/router.ex
+++ b/lib/ash_authentication_phoenix/router.ex
@@ -301,6 +301,7 @@ defmodule AshAuthentication.Phoenix.Router do
         ) :: Macro.t()
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defmacro sign_in_route(opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/sign-in")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.SignInLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -465,6 +466,7 @@ defmodule AshAuthentication.Phoenix.Router do
           | {atom, any}
         ]) :: Macro.t()
   defmacro sign_out_route(auth_controller, path \\ "/sign-out", opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {as, opts} = Keyword.pop(opts, :as, :auth)
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.SignOutLive)
     {otp_app, opts} = Keyword.pop(opts, :otp_app)
@@ -578,6 +580,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro reset_route(opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/password-reset")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.ResetLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -838,6 +841,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro totp_setup_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/totp-setup")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.TotpSetupLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -1072,6 +1076,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro webauthn_setup_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/webauthn-setup")
 
     {live_view, opts} =
@@ -1186,6 +1191,7 @@ defmodule AshAuthentication.Phoenix.Router do
       end
   """
   defmacro recovery_code_verify_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/recovery-code-verify")
 
     {live_view, opts} =
@@ -1296,6 +1302,7 @@ defmodule AshAuthentication.Phoenix.Router do
       end
   """
   defmacro recovery_code_display_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/recovery-codes")
 
     {live_view, opts} =
@@ -1421,6 +1428,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro confirm_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/#{strategy}")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.ConfirmLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -1544,6 +1552,7 @@ defmodule AshAuthentication.Phoenix.Router do
           ]
         ) :: Macro.t()
   defmacro magic_sign_in_route(resource, strategy, opts \\ []) do
+    opts = expand_opts_aliases(opts, __CALLER__)
     {path, opts} = Keyword.pop(opts, :path, "/#{strategy}")
     {live_view, opts} = Keyword.pop(opts, :live_view, AshAuthentication.Phoenix.MagicSignInLive)
     {as, opts} = Keyword.pop(opts, :as, :auth)
@@ -1631,6 +1640,21 @@ defmodule AshAuthentication.Phoenix.Router do
     |> Map.put("tenant", Ash.PlugHelpers.get_tenant(conn))
     |> Map.put("context", Ash.PlugHelpers.get_context(conn))
   end
+
+  # Expands option aliases as if inside a function so they become runtime
+  # rather than compile-time dependencies of the calling router.
+  defp expand_opts_aliases(opts, env) do
+    if Macro.quoted_literal?(opts) do
+      Macro.prewalk(opts, &expand_alias(&1, env))
+    else
+      opts
+    end
+  end
+
+  defp expand_alias({:__aliases__, _, _} = alias, env),
+    do: Macro.expand(alias, %{env | function: {:mount, 3}})
+
+  defp expand_alias(other, _env), do: other
 
   # When using a `gettext_backend`, we generate a function in the caller's router module, involving the
   # path as unique id for the function name

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -32,6 +32,22 @@ defmodule AshAuthentication.Phoenix.RouterTest do
               ]}
   end
 
+  test "sign_in_route registers on_mount hooks and layout given as options" do
+    route =
+      AshAuthentication.Phoenix.Test.Router
+      |> Phoenix.Router.routes()
+      |> Enum.find(&(&1.path == "/sign-in-on-mount"))
+
+    {_, _, _, %{extra: extra}} = route.metadata.phoenix_live_view
+
+    assert Enum.any?(
+             extra.on_mount,
+             &(&1.id == {AshAuthentication.Phoenix.Test.OnMountHook, :default})
+           )
+
+    assert extra.layout == {AshAuthentication.Phoenix.Test.HomeLive, :live}
+  end
+
   test "oauth2/oidc callback routes accept both GET and POST" do
     by_path =
       %{resources: [Example.Accounts.User]}

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -48,6 +48,22 @@ defmodule AshAuthentication.Phoenix.RouterTest do
     assert extra.layout == {AshAuthentication.Phoenix.Test.HomeLive, :live}
   end
 
+  test "totp_2fa_route registers on_mount hooks and layout given as options" do
+    route =
+      AshAuthentication.Phoenix.Test.Router
+      |> Phoenix.Router.routes()
+      |> Enum.find(&(&1.path == "/totp-2fa-on-mount"))
+
+    {_, _, _, %{extra: extra}} = route.metadata.phoenix_live_view
+
+    assert Enum.any?(
+             extra.on_mount,
+             &(&1.id == {AshAuthentication.Phoenix.Test.OnMountHook, :default})
+           )
+
+    assert extra.layout == {AshAuthentication.Phoenix.Test.HomeLive, :live}
+  end
+
   test "oauth2/oidc callback routes accept both GET and POST" do
     by_path =
       %{resources: [Example.Accounts.User]}

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -91,6 +91,11 @@ defmodule AshAuthentication.Phoenix.Test.WebAuthnComponentsLive do
   end
 end
 
+defmodule AshAuthentication.Phoenix.Test.OnMountHook do
+  @moduledoc false
+  def on_mount(:default, _params, _session, socket), do: {:cont, socket}
+end
+
 defmodule AshAuthentication.Phoenix.Test.Router do
   @moduledoc false
   alias AshAuthentication.Phoenix.Test.ComponentsLive
@@ -146,6 +151,13 @@ defmodule AshAuthentication.Phoenix.Test.Router do
                     AshAuthentication.Phoenix.Overrides.Default
                   ],
                   as: :password_toggle
+
+    # on_mount and layout options for router_test
+    sign_in_route path: "/sign-in-on-mount",
+                  auth_routes_prefix: "/auth",
+                  on_mount: [AshAuthentication.Phoenix.Test.OnMountHook],
+                  layout: {AshAuthentication.Phoenix.Test.HomeLive, :live},
+                  as: :on_mount_hooks
 
     # Custom LiveView for components testing
     sign_in_route path: "/custom_lv",

--- a/test/support/phoenix.ex
+++ b/test/support/phoenix.ex
@@ -159,6 +159,14 @@ defmodule AshAuthentication.Phoenix.Test.Router do
                   layout: {AshAuthentication.Phoenix.Test.HomeLive, :live},
                   as: :on_mount_hooks
 
+    totp_2fa_route(Example.Accounts.User, :totp,
+      path: "/totp-2fa-on-mount",
+      auth_routes_prefix: "/auth",
+      on_mount: [AshAuthentication.Phoenix.Test.OnMountHook],
+      layout: {AshAuthentication.Phoenix.Test.HomeLive, :live},
+      as: :totp_2fa_on_mount
+    )
+
     # Custom LiveView for components testing
     sign_in_route path: "/custom_lv",
                   auth_routes_prefix: "/auth",


### PR DESCRIPTION
Module references in route macro options no longer become compile-time dependencies of the calling router, so it stops recompiling whenever those modules (or anything they reach) change. Behaviour is unchanged.

## Problem

The route macros (`sign_in_route`, `magic_sign_in_route`, `reset_route`, `confirm_route`, `sign_out_route`, and the TOTP/WebAuthn/recovery-code routes) splice their options into module-body code verbatim, so modules referenced in `on_mount:`, `layout:`, `overrides:` or `live_view:` become **compile-time dependencies** of the app's router. Since layouts and on_mount hooks typically reach the rest of the web layer, this recompiles the router on nearly every LiveView edit (visible with `mix xref trace lib/my_app_web/router.ex`).

## Change

Expand aliases in the options under an env that pretends to be inside a function, so the compiler tracer records them as runtime rather than compile-time dependencies. This is the same technique `ash_authentication_live_session` already uses (an identical `Macro.quoted_literal?`-gated prewalk with a `{:mount, 3}` env), and that `auth_routes/2` and `Phoenix.LiveView.Router.live_session/3` use for their own module-bearing options.

- Options that are quoted literals resolve to the same module atoms as before, just earlier and without the dependency; non-literal options pass through untouched.
- Adds a test router variant passing `on_mount:`/`layout:` (previously uncovered) and a test asserting the generated live_session metadata contains the expanded hook and layout.
