### PR TITLE
fix: Apply overrides to the generated `sign_out_route`

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.setup.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.setup.ex
@@ -160,7 +160,8 @@ if Code.ensure_loaded?(Igniter) do
           "/",
           """
           auth_routes AuthController, #{inspect(options[:user])}, path: "/auth"
-          sign_out_route AuthController
+          sign_out_route AuthController, "/sign-out",
+            overrides: [#{inspect(overrides)}, #{override_module}]
 
           # Remove these if you'd like to use your own authentication views
           sign_in_route register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth", on_mount: [{#{inspect(web_module)}.LiveUserAuth, :live_no_user}],

--- a/lib/mix/tasks/ash_authentication_phoenix.setup.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.setup.ex
@@ -161,26 +161,26 @@ if Code.ensure_loaded?(Igniter) do
           """
           auth_routes AuthController, #{inspect(options[:user])}, path: "/auth"
           sign_out_route AuthController, "/sign-out",
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove these if you'd like to use your own authentication views
           sign_in_route register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth", on_mount: [{#{inspect(web_module)}.LiveUserAuth, :live_no_user}],
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not want to use the reset password feature
-          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, #{override_module}]
+          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not use the confirmation strategy
           confirm_route #{inspect(options[:user])},
             :confirm_new_user,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not use the magic link strategy.
           magic_sign_in_route #{inspect(options[:user])},
             :magic_link,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
           """,
           with_pipelines: [:browser],
           arg2: Igniter.Libs.Phoenix.web_module(igniter),

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -39,9 +39,9 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
 
     base_override =
       if context.daisy_ui do
-        AshAuthentication.Phoenix.Overrides.DaisyUI
+        "AshAuthentication.Phoenix.Overrides.DaisyUI"
       else
-        AshAuthentication.Phoenix.Overrides.Default
+        "AshAuthentication.Phoenix.Overrides.Default"
       end
 
     [igniter: igniter, base_override: base_override]

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -345,7 +345,10 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     + |  scope "/", TestWeb do
     + |    pipe_through([:browser])
     + |    auth_routes(AuthController, Test.Accounts.User, path: "/auth")
-    + |    sign_out_route(AuthController)
+    + |
+    + |    sign_out_route(AuthController, "/sign-out",
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
+    + |    )
     + |
     + |    # Remove these if you'd like to use your own authentication views
     + |    sign_in_route(


### PR DESCRIPTION
I noticed in the app I'm working on that the sign-out page did not have the DaisyUI overrides applied like other pages. `sign_out_route` does accept overrides, but none were being passed in. Now they are, the same as other routes!

Note: I also fixed the `Elixir.` prefix that was being added to override module names, like this:

```elixir
    # Remove this if you do not use the magic link strategy.
    magic_sign_in_route(MyApp.Accounts.User, :magic_link,
      auth_routes_prefix: "/auth",
      overrides: [MyAppWeb.AuthOverrides, Elixir.AshAuthentication.Phoenix.Overrides.DaisyUI]
    )
```