### PR TITLE
fix: apply overrides to generated sign-out route

### DIFF
--- a/lib/mix/tasks/ash_authentication_phoenix.install.ex
+++ b/lib/mix/tasks/ash_authentication_phoenix.install.ex
@@ -172,26 +172,27 @@ if Code.ensure_loaded?(Igniter) do
           "/",
           """
           auth_routes AuthController, #{inspect(options[:user])}, path: "/auth"
-          sign_out_route AuthController
+          sign_out_route AuthController, "/sign-out",
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove these if you'd like to use your own authentication views
           sign_in_route register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth", on_mount: [{#{inspect(web_module)}.LiveUserAuth, :live_no_user}],
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not want to use the reset password feature
-          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, #{override_module}]
+          reset_route auth_routes_prefix: "/auth", overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not use the confirmation strategy
           confirm_route #{inspect(options[:user])},
             :confirm_new_user,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
 
           # Remove this if you do not use the magic link strategy.
           magic_sign_in_route #{inspect(options[:user])},
             :magic_link,
             auth_routes_prefix: "/auth",
-            overrides: [#{inspect(overrides)}, #{override_module}]
+            overrides: [#{inspect(overrides)}, #{inspect(override_module)}]
           """,
           with_pipelines: [:browser],
           arg2: Igniter.Libs.Phoenix.web_module(igniter),

--- a/test/mix/tasks/ash_authentication_phoenix.install_test.exs
+++ b/test/mix/tasks/ash_authentication_phoenix.install_test.exs
@@ -39,9 +39,9 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
 
     base_override =
       if context.daisy_ui do
-        AshAuthentication.Phoenix.Overrides.DaisyUI
+        "AshAuthentication.Phoenix.Overrides.DaisyUI"
       else
-        AshAuthentication.Phoenix.Overrides.Default
+        "AshAuthentication.Phoenix.Overrides.Default"
       end
 
     [igniter: igniter, base_override: base_override]
@@ -257,7 +257,10 @@ defmodule Mix.Tasks.AshAuthenticationPhoenix.InstallTest do
     + |  scope "/", TestWeb do
     + |    pipe_through([:browser])
     + |    auth_routes(AuthController, Test.Accounts.User, path: "/auth")
-    + |    sign_out_route(AuthController)
+    + |
+    + |    sign_out_route(AuthController, "/sign-out",
+    + |      overrides: [TestWeb.AuthOverrides, #{base_override}]
+    + |    )
     + |
     + |    # Remove these if you'd like to use your own authentication views
     + |    sign_in_route(


### PR DESCRIPTION
Backport of #760 to the v2.x stable branch.

## Summary

- apply the configured override modules to the generated `sign_out_route`
- generate base override module names without the `Elixir.` prefix
- update installer coverage for default and DaisyUI overrides

## Testing

- `mix test test/mix/tasks/ash_authentication_phoenix.install_test.exs`
- `mix check --no-retry`